### PR TITLE
Update npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
 .babelrc
 .editorconfig
 .gitignore
+.paket
+.travis.yml
+.npmignore
 *.log
 *.fs
 *.fsproj

--- a/IML/DeviceScannerDaemon/EventTypes.fs
+++ b/IML/DeviceScannerDaemon/EventTypes.fs
@@ -36,7 +36,7 @@ type AddEvent = {
   ID_VENDOR: string option;
   ID_MODEL: string;
   ID_SERIAL: string option;
-  ID_FS_TYPE: string;
+  ID_FS_TYPE: string option;
   ID_PART_ENTRY_NUMBER: string option;
   IML_SIZE: string option;
 }
@@ -87,7 +87,7 @@ let private devPath = findOrFail "DEVPATH"
 let private idVendor = findOrNone "ID_VENDOR"
 let private idModel = findOrFail "ID_MODEL"
 let private idSerial = findOrNone "ID_SERIAL"
-let private idFsType = findOrFail "ID_FS_TYPE"
+let private idFsType = findOrNone "ID_FS_TYPE"
 let private idPartEntryNumber = findOrNone "ID_PART_ENTRY_NUMBER"
 let private imlSize = findOrNone "IML_SIZE"
 

--- a/IML/DeviceScannerDaemon/Handlers.fs
+++ b/IML/DeviceScannerDaemon/Handlers.fs
@@ -12,7 +12,7 @@ open System.Collections.Generic
 open IML.DeviceScannerDaemon.ParseUdevDB
 open IML.UdevEventTypes.EventTypes
 
-let private deviceMap:IDictionary<string, AddEvent> = dict[||]
+let private deviceMap = Dictionary<string, AddEvent>()
 
 let dataHandler (c:Net.Socket) = function
   | ReadEventMatch(_) ->

--- a/IML/DeviceScannerDaemon/systemd-units/device-scanner.service
+++ b/IML/DeviceScannerDaemon/systemd-units/device-scanner.service
@@ -6,6 +6,6 @@ DefaultDependencies=false
 [Service]
 Restart=always
 Environment=NODE_ENV=production
-ExecStart=/usr/bin/node /usr/lib/iml-device-scanner-daemon/device-scanner-daemon
+ExecStart=/usr/bin/node /usr/lib64/iml-device-scanner-daemon/device-scanner-daemon
 StandardOutput=journal+console
 StandardError=journal+console

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,12 +21,12 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     cd /vagrant
-    mkdir -p /usr/lib/iml-device-scanner-daemon
-    cp dist/device-scanner-daemon/device-scanner-daemon /usr/lib/iml-device-scanner-daemon
+    mkdir -p /usr/lib64/iml-device-scanner-daemon
+    cp dist/device-scanner-daemon/device-scanner-daemon /usr/lib64/iml-device-scanner-daemon
     cp dist/block-device-listener/block-device-listener /lib/udev
     chmod 777 /lib/udev/block-device-listener
     cp dist/block-device-listener/udev-rules/99-iml-device-scanner.rules /etc/udev/rules.d/
-    cp dist/device-scanner-daemon/systemd-units/* /usr/lib/systemd/system
+    cp dist/device-scanner-daemon/systemd-units/* /usr/lib64/systemd/system
     systemctl enable device-scanner.socket
     systemctl start device-scanner.socket
   SHELL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "device-scanner",
-  "version": "1.0.0",
+  "name": "@iml/device-scanner",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3019,9 +3019,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.6.0.tgz",
-      "integrity": "sha512-oiy1f6Mrk5506IWaee64ruOJR8/BVzHwxF0R7B+FvhaU/L4eRfwZgwF+VTzaxcBBu/iYP/386Hxw9vFJjR/A5g==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.6.1.tgz",
+      "integrity": "sha512-f85qBoQiqiFM/sCmJaN4Lagj9bqMcv38vCftqp4GfVessAqq3Ns6g+3gd8UXReStLLE/DGEdwiZXoFKxphKqwg==",
       "dev": true
     },
     "pretty-format": {
@@ -3344,9 +3344,9 @@
       }
     },
     "rollup": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.49.1.tgz",
-      "integrity": "sha512-e65jFl1/vA+JedVkr39JIY1PGJ9rApYQxF/ZUJpR3ey3yDB4OcLFKuIpMB2vevOcwV+6jgKqvaIGYTWvIfBYpA==",
+      "version": "0.49.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.49.2.tgz",
+      "integrity": "sha512-9mySqItSwq5/dXYQyFGrrzqV282EZfz4kSCU2m4e6OjgqLmIsp9zK6qNQ6wbBWR4EhASEqQMBQ/IF45jaNPAtw==",
       "dev": true
     },
     "rollup-plugin-cleanup": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@iml/device-scanner",
   "description": "Builds an in-memory representation of devices. Uses udev rules to handle change events.",
   "author": "IML Team",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -32,8 +32,8 @@
     "jest": "^20.0.4",
     "jest-fable-preprocessor": "^1.3.0",
     "pre-commit": "1.2.2",
-    "prettier": "^1.6.0",
-    "rollup": "^0.49.1",
+    "prettier": "^1.6.1",
+    "rollup": "^0.49.2",
     "rollup-plugin-cleanup": "^1.0.1",
     "rollup-plugin-fable": "^1.1.0",
     "rollup-plugin-filesize": "^1.4.2",


### PR DESCRIPTION
Update npmignore to not publish a few more files.
In addition, switch from IDictionary to Dictionary and make ID_FS_TYPE optional.

Signed-off-by: Joe Grund <joe.grund@intel.com>