### PR TITLE
Exclude unwanted devices and get ro status

### DIFF
--- a/IML/BlockDeviceListener/udev-rules/99-iml-device-scanner.rules
+++ b/IML/BlockDeviceListener/udev-rules/99-iml-device-scanner.rules
@@ -1,10 +1,17 @@
+# We are only handling block devices
 SUBSYSTEM!="block", GOTO="iml_device_scanner_end"
+
+# Ignore any devices we aren't interested in
+KERNEL=="fd*|loop*|ram*|sr[0-9]*", GOTO="iml_device_scanner_end"
 
 # Get scsi_id page 80 info. This is *only* needed to keep compat with existing IML installs.
 ACTION=="add|change", PROGRAM="/lib/udev/scsi_id -g -p 0x80 -d $devnode", RESULT=="?*", ENV{IML_SCSI_80}="$result"
 
 # Get scsi_id page 83 info. This is *only* needed to keep compat with existing IML installs.
 ACTION=="add|change", PROGRAM="/lib/udev/scsi_id -g -p 0x83 -d $devnode", RESULT=="?*", ENV{IML_SCSI_83}="$result"
+
+# Get ro state whenever there is an add or change on the device
+ACTION=="add|change", PROGRAM="/sbin/blockdev --getro $devnode", RESULT=="?*", ENV{IML_IS_RO}="$result"
 
 # Read size from /sys and add it to the device
 ACTION=="add|change", ENV{IML_SIZE}="$attr{size}"

--- a/IML/DeviceScannerDaemon/EventTypes.fs
+++ b/IML/DeviceScannerDaemon/EventTypes.fs
@@ -44,6 +44,7 @@ type AddEvent = {
   IML_SIZE: string option;
   IML_SCSI_80: string option;
   IML_SCSI_83: string option;
+  IML_IS_RO: bool option;
 }
 
 /// The data received from a
@@ -112,6 +113,7 @@ let private parseIdPartEntryNumber = findOrNone "ID_PART_ENTRY_NUMBER"
 let private parseImlSize = findOrNone "IML_SIZE"
 let private parseImlScsi80 = findOrNone "IML_SCSI_80"
 let private parseImlScsi83 = findOrNone "IML_SCSI_83"
+let private parseImlRo = findOrNone "IML_IS_RO"
 
 let extractAddEvent x =
   let devType =
@@ -135,6 +137,14 @@ let extractAddEvent x =
   let devlinks = parseDevlinks x
   let devname = parseDevName x
 
+  let imlRo =
+    x
+      |> parseImlRo
+      |> Option.map(function
+        | "1" -> true
+        | _ -> false
+      )
+
   let idFsType =
     x
       |> parseIdFsType
@@ -157,6 +167,7 @@ let extractAddEvent x =
     ID_FS_TYPE = idFsType;
     ID_PART_ENTRY_NUMBER = parseIdPartEntryNumber x |> Option.map(int);
     IML_SIZE = parseImlSize x;
+    IML_IS_RO = imlRo;
     IML_SCSI_80 = parseImlScsi80 x |> trimOpt;
     IML_SCSI_83 = parseImlScsi83 x |> trimOpt;
   }


### PR DESCRIPTION
We do not want to list devices the are cdroms, ramdisks, loop devices, and floppy disks.

Exclude all these devices with a new rule.

In addition, add a rule that will tell if a device is read-only. This will be emitted on an add or change event.