### PR TITLE
Cast empty IML_SIZE to None

### DIFF
--- a/IML/DeviceScannerDaemon/EventTypes.fs
+++ b/IML/DeviceScannerDaemon/EventTypes.fs
@@ -95,7 +95,9 @@ let private findOrFail (key:string) x =
     | Some(x) -> unwrapString x
     | None -> failwith (sprintf "Could not find key %s in %O" key x)
 
-let trimOpt = Option.map(fun (x:string) -> x.Trim())
+let private emptyStrToNone x = if x = "" then None else Some(x)
+
+let private trimOpt = Option.map(fun (x:string) -> x.Trim())
 
 let private findOrNone key x =
   x |> Map.tryFind key |> Option.bind str
@@ -145,13 +147,6 @@ let extractAddEvent x =
         | _ -> false
       )
 
-  let idFsType =
-    x
-      |> parseIdFsType
-      |> Option.bind(fun x ->
-        if x = "" then None else Some(x)
-      )
-
   {
     ACTION = "add";
     MAJOR = parseMajor x;
@@ -164,9 +159,9 @@ let extractAddEvent x =
     ID_VENDOR = parseIdVendor x;
     ID_MODEL = parseIdModel x;
     ID_SERIAL = parseIdSerial x;
-    ID_FS_TYPE = idFsType;
+    ID_FS_TYPE = parseIdFsType x |> Option.bind(emptyStrToNone);
     ID_PART_ENTRY_NUMBER = parseIdPartEntryNumber x |> Option.map(int);
-    IML_SIZE = parseImlSize x;
+    IML_SIZE = parseImlSize x |> Option.bind(emptyStrToNone);
     IML_IS_RO = imlRo;
     IML_SCSI_80 = parseImlScsi80 x |> trimOpt;
     IML_SCSI_83 = parseImlScsi83 x |> trimOpt;

--- a/IML/DeviceScannerDaemon/EventTypes.fs
+++ b/IML/DeviceScannerDaemon/EventTypes.fs
@@ -181,7 +181,7 @@ let (|RemoveEventMatch|_|) x =
       {
         ACTION = "remove";
         DEVLINKS = parseDevlinks x;
-        DEVPATH = parseDevName x;
+        DEVPATH = parseDevPath x;
         MAJOR = parseMajor x;
         MINOR = parseMinor x;
       }

--- a/IML/DeviceScannerDaemon/EventTypes.fs
+++ b/IML/DeviceScannerDaemon/EventTypes.fs
@@ -25,6 +25,9 @@ let (|DiskMatch|_|) (x:string) =
   else
     None
 
+[<Erase>]
+type DevPath = DevPath of string
+
 /// The data received from a
 /// udev block device add event
 type AddEvent = {
@@ -34,7 +37,7 @@ type AddEvent = {
   DEVLINKS: string option;
   PATHS: string array option;
   DEVNAME: string;
-  DEVPATH: string;
+  DEVPATH: DevPath;
   DEVTYPE: DevType;
   ID_VENDOR: string option;
   ID_MODEL: string option;
@@ -52,7 +55,7 @@ type AddEvent = {
 type RemoveEvent = {
   ACTION: string;
   DEVLINKS: string option;
-  DEVPATH: string;
+  DEVPATH: DevPath;
   MAJOR: string;
   MINOR: string;
 }
@@ -106,7 +109,7 @@ let private parseMajor = findOrFail "MAJOR"
 let private parseMinor =  findOrFail "MINOR"
 let private parseDevlinks = findOrNone "DEVLINKS"
 let private parseDevName = findOrFail "DEVNAME"
-let private parseDevPath = findOrFail "DEVPATH"
+let private parseDevPath x = findOrFail "DEVPATH" x |> DevPath
 let private parseIdVendor = findOrNone "ID_VENDOR"
 let private parseIdModel = findOrNone "ID_MODEL"
 let private parseIdSerial = findOrNone "ID_SERIAL"

--- a/IML/DeviceScannerDaemon/Handlers.fs
+++ b/IML/DeviceScannerDaemon/Handlers.fs
@@ -11,7 +11,7 @@ open System.Collections.Generic
 
 open IML.DeviceScannerDaemon.EventTypes
 
-let private deviceMap = Dictionary<string, AddEvent>()
+let private deviceMap = Dictionary<DevPath, AddEvent>()
 
 let dataHandler' (``end``:string option -> unit) = function
   | InfoEventMatch(_) ->

--- a/IML/DeviceScannerDaemon/HandlersTest.fs
+++ b/IML/DeviceScannerDaemon/HandlersTest.fs
@@ -23,7 +23,7 @@ testList "Data Handler" [
   yield! testFixture withSetup [
     "Should call end with map for info event", fun (``end``, handler) ->
       handler (toJson """{ "ACTION": "info" }""")
-      ``end`` <?> Some("{}")
+      ``end`` <?> Some("{}");
 
     "Should call end for add event", fun (``end``, handler) ->
        handler addObj
@@ -40,7 +40,27 @@ testList "Data Handler" [
       with
         | ex ->
           ``end`` <?> None
-          expect.Invoke(ex.Message).toEqual("Handler got a bad match")
+          expect.Invoke(ex.Message).toEqual("Handler got a bad match");
 
+    "Should remove an item", fun (``end``, handler) ->
+        handler addObj
+
+        handler (toJson """{ "ACTION": "info" }""")
+
+        ``end`` <?> Some("{\"/devices/pci0000:00/0000:00:01.1/ata1/host1/\
+                          target1:0:0/1:0:0:0/block/sdb/sdb1\":\
+                          {\"ACTION\":\"add\",\"MAJOR\":\"8\",\"MINOR\":\"17\",\"DEVLINKS\":\"/dev/disk\
+                          /by-id/ata-VBOX_HARDDISK_VB304a0a0f-15e93f07-part1 /dev/disk/by-path/pci-0000:00:01.1-ata-1.0-part1\",\
+                          \"PATHS\":[\"/dev/sdb1\",\"/dev/disk/by-id/ata-VBOX_HARDDISK_VB304a0a0f-15e93f07-part1\",\"/dev/disk/by-path/pci-0000:00:01.1-ata-1.0-part1\"],\
+                          \"DEVNAME\":\"/dev/sdb1\",\"DEVPATH\":\"/devices/pci0000:00/0000:00:01.1/ata1/host1/target1:0:0/1:0:0:0/block/sdb/sdb1\",\
+                          \"DEVTYPE\":\"partition\",\"ID_VENDOR\":null,\"ID_MODEL\":\"VBOX_HARDDISK\",\
+                          \"ID_SERIAL\":\"VBOX_HARDDISK_VB304a0a0f-15e93f07\",\"ID_FS_TYPE\":\"LVM2_member\",\
+                          \"ID_PART_ENTRY_NUMBER\":1,\"IML_SIZE\":\"81784832\",\"IML_SCSI_80\":null,\"IML_SCSI_83\":null,\"IML_IS_RO\":null}}")
+
+        handler removeObj
+
+        handler (toJson """{ "ACTION": "info" }""")
+
+        ``end`` <?> Some("{}");
   ]
 ]


### PR DESCRIPTION
There is a case where `IML_SIZE` can come through as an empty string.

In this case cast it to `None`.

We already have some code that transforms `str -> Some(str)` so extract it to a fn.