### PR TITLE
Add maybe computation expression

### DIFF
--- a/Base.fsproj
+++ b/Base.fsproj
@@ -3,6 +3,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="IML/Maybe.fs" />
+    <Compile Include="IML/MaybeTest.fs" />
     <Compile Include="IML/NodeHelpers.fs" />
     <Compile Include="IML/BlockDeviceListener/Listener.fs" />
     <Compile Include="IML/BlockDeviceListener/ListenerTest.fs" />

--- a/IML/Maybe.fs
+++ b/IML/Maybe.fs
@@ -8,4 +8,6 @@ type MaybeBuilder() =
     member this.Delay(f) = f()
     member this.Return(x) = Some x
 
+    member this.ReturnFrom(x) = x
+
 let maybe = MaybeBuilder();

--- a/IML/Maybe.fs
+++ b/IML/Maybe.fs
@@ -1,0 +1,11 @@
+module IML.Maybe
+
+type MaybeBuilder() =
+    member this.Bind(x, f) =
+        match x with
+        | Some(x) -> f(x)
+        | _ -> None
+    member this.Delay(f) = f()
+    member this.Return(x) = Some x
+
+let maybe = MaybeBuilder();

--- a/IML/MaybeTest.fs
+++ b/IML/MaybeTest.fs
@@ -21,3 +21,12 @@ test "None" <| fun () ->
   }
 
   x == None
+
+test "Return Some" <| fun () ->
+  let x = maybe {
+    let! y = Some(4);
+
+    return! Some(6 + y)
+  }
+
+  x == Some 10

--- a/IML/MaybeTest.fs
+++ b/IML/MaybeTest.fs
@@ -1,0 +1,23 @@
+module IML.MaybeTest
+
+open IML.Maybe
+open Fable.Import.Jest
+open Matchers
+
+test "Some" <| fun () ->
+  let x = maybe {
+    let! y = Some(5)
+
+    return y + 5
+  }
+
+  x == Some(10)
+
+test "None" <| fun () ->
+  let x = maybe {
+    let! y = None
+
+    return y + 5
+  }
+
+  x == None


### PR DESCRIPTION
  Add a computation expression for `maybe`
  so we can work with `Option`s without directly
  dealing with the module fns.

Signed-off-by: Joe Grund <joe.grund@intel.com>