### PR TITLE
Create a Vagrant Test Framework to be used for Integration testing

### DIFF
--- a/Base.fsproj
+++ b/Base.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="IML/DeviceScannerDaemon/Handlers.fs" />
     <Compile Include="IML/DeviceScannerDaemon/HandlersTest.fs" />
     <Compile Include="IML/DeviceScannerDaemon/Server.fs" />
+    <Compile Include="IML/Test/VagrantTestFramework.fs" />
   </ItemGroup>
   <Import Project=".paket\Paket.Restore.targets" />
 </Project>

--- a/Base.fsproj
+++ b/Base.fsproj
@@ -6,6 +6,7 @@
     <Compile Include="IML/Maybe.fs" />
     <Compile Include="IML/MaybeTest.fs" />
     <Compile Include="IML/NodeHelpers.fs" />
+    <Compile Include="IML/NodeHelpersTest.fs" />
     <Compile Include="IML/StringUtils.fs" />
     <Compile Include="IML/JsonDecoders.fs" />
     <Compile Include="IML/JsonDecodersTest.fs" />

--- a/IML/EventListener/Listener.fs
+++ b/IML/EventListener/Listener.fs
@@ -6,7 +6,7 @@ module IML.EventListener.Listener
 
 open Fable.Import.JS
 open Fable.Import.Node
-open NodeHelpers
+open NodeHelpers.NetHelpers
 
 let private client = connect { path = "/var/run/device-scanner.sock"; }
 

--- a/IML/NodeHelpers.fs
+++ b/IML/NodeHelpers.fs
@@ -4,8 +4,11 @@
 
 module NodeHelpers
 
+open System
 open Fable.Import.Node
+open Fable.Core.JsInterop
 open Fable.Core
+open Fable.PowerPack
 
 
   [<AutoOpen>]
@@ -15,10 +18,119 @@ open Fable.Core
       path: string
     }
 
+    type ShellError = {
+      cmd : string;
+      code : int;
+      msg : string;
+      stdout : U2<string, Buffer.Buffer>;
+      stderr : U2<string, Buffer.Buffer>;
+      signal : string option;
+      failed : bool
+    }
+
+    type ShellSuccess = {
+      cmd : string;
+      stdout : U2<string, Buffer.Buffer>;
+      stderr : U2<string, Buffer.Buffer>;
+      code : int;
+      failed : bool
+    }
+
     let ``end`` (c:Net.Socket) = function
       | Some(x) -> c.``end``(x)
       | None -> c.``end``()
 
     let onceConnect (fn:unit -> unit) (c:Net.Socket)  = c.once("connect", fn) :?> Net.Socket
 
+    let onConnect (fn:unit -> unit) (c:Net.Socket)  = c.on("connect", fn) :?> Net.Socket
+
+    let onData (fn:string -> unit) (c:Stream.Stream) = c.on("data", fn) :?> Net.Socket
+
+    let onError (fn:string -> unit) (c:Stream.Stream) = c.on("error", fn) :?> Net.Socket
+
     let connect (x:NetPath) = Net.connect x
+
+    let createServer opts serverHandler = Net.createServer(opts, serverHandler)
+
+    let execFn cmd (res:Result<ShellSuccess, ShellError> -> unit) (errOpt:ChildProcess.ExecError option) stdout stderr =
+        match errOpt with
+            | None ->
+                Ok ({cmd = cmd;
+                            stdout = stdout;
+                            stderr = stderr;
+                            code = 0;
+                            failed = false})
+            | Some(err) ->
+                Error ({cmd = cmd;
+                        code = err.code;
+                        msg = err.message;
+                        signal = err.signal;
+                        failed = true;
+                        stdout = stdout;
+                        stderr = stderr})
+        |> res
+
+    let shell(cmd : string) (opts: ChildProcess.ExecOptions option) =
+      let opts:ChildProcess.ExecOptions =
+        match opts with
+          | None ->
+             let o = createEmpty<ChildProcess.ExecOptions>
+             o.encoding <- Some("utf8")
+             o
+          | Some(x) -> x
+
+      Promise.create(
+          fun res _ ->
+              ChildProcess.exec(cmd, opts, (execFn cmd res)) |> ignore
+      )
+
+    let spawnFn (cmd:string) (args:ResizeArray<string> option) (opts: ChildProcess.ExecOptions option) =
+      let args:ResizeArray<string> =
+        match args with
+          | None -> new ResizeArray<String>()
+          | Some(x) -> x
+      let opts:ChildProcess.ExecOptions =
+        match opts with
+          | None ->
+            let o = createEmpty<ChildProcess.ExecOptions>
+            o.encoding <- Some("utf8")
+            o
+          | Some(x) -> x
+
+
+      ChildProcess.spawn(cmd, args, opts)
+
+
+[<AutoOpen>]
+  module ChildProcessHelpers =
+    type Stdout = Stdout of string
+    type Stderr = Stderr of string
+
+    type ExecOk = Stdout * Stderr
+    type ExecErr = ChildProcess.ExecError * Stdout * Stderr
+
+    let private toStr = function
+      | U2.Case1(x) -> x
+      | U2.Case2(x:Buffer.Buffer) -> x.toString "utf8"
+
+    let exec (cmd:string) =
+      Promise.create(fun res _ ->
+
+        let opts = createEmpty<ChildProcess.ExecOptions>
+
+        ChildProcess.exec(cmd, opts, (fun e stdout' stderr' ->
+          let stdout = stdout' |> toStr |> Stdout
+          let stderr = stderr' |> toStr |> Stderr
+
+          match e with
+            | Some (e) ->
+              (e, stdout, stderr)
+                |> Error
+                |> res
+            | None ->
+              (stdout, stderr)
+                |> Ok
+                |> res
+        ))
+          |> ignore
+      )

--- a/IML/NodeHelpersTest.fs
+++ b/IML/NodeHelpersTest.fs
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+module IML.NodeHelpersTest
+
+open Fable.Import.Jest
+open Matchers
+open Fable.Import.JS
+open Fable.Core.JsInterop
+open Fable.Import.Node
+open Globals
+
+testList "NodeHelpers" [
+  let withSetup f () =
+    let onFn evt (fn:string -> obj) = fn evt
+    let mockOnAndOnce = Matcher2<string, string -> obj, obj>(onFn)
+    let mockConnect = Matcher<obj, obj>()
+    let mockFn = Matcher<string, obj>(fun evt -> createObj ["name" ==> evt])
+
+    jest.mock("net", fun () -> createObj ["connect" ==> mockConnect.Mock])
+
+    let nodeHelpers = require.Invoke "./NodeHelpers.fs"
+    f(nodeHelpers, mockConnect, mockOnAndOnce, mockFn)
+
+  yield! testFixture withSetup [
+    "should expose onceConnect", fun (nodeHelpers, _, mockOnce, mockFn) ->
+      let c = createObj ["once" ==> mockOnce.Mock]
+      nodeHelpers?NetHelpers?onceConnect (id, c) |> ignore
+      mockOnce.CalledWith "connect" (expect.any Function)
+
+    "should expose onConnect", fun (nodeHelpers, _, mockOn, mockFn) ->
+      let c = createObj ["on" ==> mockOn.Mock]
+      nodeHelpers?NetHelpers?onConnect (id, c) |> ignore
+      mockOn.CalledWith "connect" (expect.any Function)
+
+    "should expose onData", fun (nodeHelpers, _, mockOn, mockFn) ->
+      let c = createObj ["on" ==> mockOn.Mock]
+      nodeHelpers?NetHelpers?onData (id, c) |> ignore
+      mockOn.CalledWith "data" (expect.any Function)
+
+    "should expose connect with NetPath", fun (nodeHelpers, mockConnect, _, _) ->
+      nodeHelpers?NetHelpers?connect (createObj ["path" ==> "/var/run/device-scanner.sock" ]) |> ignore
+      mockConnect.CalledWith (createObj ["path" ==> "/var/run/device-scanner.sock"])
+
+
+    // "should call connect", fun (_, mockOnce, _) ->
+    //   mockOnce.CalledWith "connect" (expect.any Function);
+
+    // "should call end with process data", fun (_, mockOnce, mockEnd) ->
+    //   mockOnce.LastCall
+    //     |> snd
+    //     |> fun fn -> fn()
+    //     |> ignore
+
+    //   mockEnd.CalledWith <| expect.any String
+  ]
+]

--- a/IML/Test/VagrantTestFramework.fs
+++ b/IML/Test/VagrantTestFramework.fs
@@ -1,0 +1,30 @@
+module IML.Test.VagrantTestFramework
+
+open Fable.Import.Node
+open Fable.Core
+open NodeHelpers
+
+type Out = {
+  err: ChildProcess.ExecError option;
+  stdout: U2<string, Buffer.Buffer>;
+  stderr: U2<string, Buffer.Buffer>
+}
+
+let private vagrantCommand (cmd:string) =
+  sprintf "vagrant %s" cmd
+
+let private shellCommand (cmd:string) =
+  sprintf "vagrant ssh default -- '%s'" cmd
+
+let vagrantStart () =
+  exec (vagrantCommand "up")
+
+let vagrantDestroy () =
+  exec (vagrantCommand "destroy -f")
+
+let vagrantRunCommand cmd () =
+  exec (shellCommand cmd)
+
+let vagrantPipeToShellCommand (cmd1:string) (cmd2:string) () =
+  let cmd = sprintf "%s | %s" cmd1 (shellCommand cmd2)
+  exec cmd

--- a/package-lock.json
+++ b/package-lock.json
@@ -5301,9 +5301,9 @@
       }
     },
     "rollup": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.52.0.tgz",
-      "integrity": "sha512-IQ+t5uoeMSHpDyeJj4uFVWj+ocS8sUbFPNKCssyCac3GVgLs62nFH6UdU0nGLRIxjasPaN7wGHEioVXbxXRaYQ==",
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.52.1.tgz",
+      "integrity": "sha512-cVOL8rUMivChVcScL7zq1JCl4+4gMiVOllnX9r2l6MlkUzyXRbBK7szGDGaFXyqZl6uruFtX+gFhize9o7iiKg==",
       "dev": true
     },
     "rollup-plugin-cleanup": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jest": "^21.2.1",
     "jest-fable-preprocessor": "^1.3.3",
     "pre-commit": "1.2.2",
-    "rollup": "^0.52.0",
+    "rollup": "^0.52.1",
     "rollup-plugin-cleanup": "^2.0.0",
     "rollup-plugin-fable": "^1.1.1",
     "rollup-plugin-filesize": "^1.5.0",


### PR DESCRIPTION
#16
 
- Enhance NodeHelpers with Shell functionality
- Update Listener to use NodeHelpers.NetHelpers
- Add VagrantTestFramework file and include it in the base project

Signed-off-by: Will Johnson <william.c1.johnson@gmail.com>