### PR TITLE
Add stream command to keep connection open

### DIFF
--- a/IML/DeviceScannerDaemon/Handlers.fs
+++ b/IML/DeviceScannerDaemon/Handlers.fs
@@ -45,7 +45,7 @@ let private updateDatasets (action:DatasetAction) (x:ZfsDataset) =
 
 let mutable private closeOnWrite = true
 
-let private getState =
+let private getState () =
   { BLOCK_DEVICES = deviceMap; ZFSPOOLS = zpoolMap }
     |> toJson
     |> Some
@@ -105,5 +105,9 @@ let dataHandler (sock:Net.Socket) x =
         raise (System.Exception "Handler got a bad match")
 
   match closeOnWrite with
-    | true -> sock.``end`` getState
-    | false -> sock.write getState |> ignore
+    | true ->
+      System.Console.Write (sprintf "writing then closing")
+      sock.``end`` (getState ())
+    | false ->
+      System.Console.Write (sprintf "writing not closing")
+      sock.write (getState ()) |> ignore

--- a/IML/DeviceScannerDaemon/Handlers.fs
+++ b/IML/DeviceScannerDaemon/Handlers.fs
@@ -105,5 +105,11 @@ let dataHandler (sock:Net.Socket) x =
         sock.``end`` None
         raise (System.Exception "Handler got a bad match")
 
-  if shouldEnd then sock.``end`` (getState ()) else sock.write (getState ()) |> ignore
+  match shouldEnd with
+    | true ->
+      System.Console.Write "shouldEnd=true, ending with state"
+      sock.``end`` (getState ())
+    | false ->
+      System.Console.Write "shouldEnd=false, writing state"
+      sock.write (getState ()) |> ignore
 

--- a/IML/DeviceScannerDaemon/Server.fs
+++ b/IML/DeviceScannerDaemon/Server.fs
@@ -12,6 +12,7 @@ open Handlers
 open NodeHelpers
 
 let serverHandler (sock:Net.Socket) =
+  console.log "client connected"
   sock
     .pipe(getJsonStream())
     .on("error", fun (e:Error) ->
@@ -19,7 +20,10 @@ let serverHandler (sock:Net.Socket) =
       sock.``end``()
     )
     .on("data", (dataHandler sock))
-    |> ignore
+    .on("end", fun (_) ->
+      console.log "client disconnected"
+    )
+  |> ignore
 
 let opts = createEmpty<Net.CreateServerOptions>
 opts.allowHalfOpen <- Some true

--- a/IML/DeviceScannerDaemon/Server.fs
+++ b/IML/DeviceScannerDaemon/Server.fs
@@ -8,17 +8,17 @@ open Fable.Import.Node
 open Fable.Import.JS
 open Fable.Core.JsInterop
 open IML.LineDelimitedJsonStream.Stream
-open IML.DeviceScannerDaemon.Handlers
+open Handlers
 open NodeHelpers
 
-let serverHandler (c:Net.Socket) =
-  c
+let serverHandler (sock:Net.Socket) =
+  sock
     .pipe(getJsonStream())
     .on("error", fun (e:Error) ->
       console.error ("Unable to parse message " + e.message)
-      c.``end``()
+      sock.``end``()
     )
-    .on("data", (dataHandler (``end`` c)))
+    .on("data", (dataHandler sock))
     |> ignore
 
 let opts = createEmpty<Net.CreateServerOptions>


### PR DESCRIPTION
A command is needed to keep stream open (and not close connection on receipt of  event) in order to enable forwarding of changes to the `device-aggregator` . This requires writing state every time an event is received. When this command is received, subsequent events will be processed and new state written to the stream without closing the connection, if a subsequent "Info" command is received, State will be written and then connection closed.