### PR TITLE
Remove andThenSucceed

### DIFF
--- a/IML/DeviceScannerDaemon/Udev.fs
+++ b/IML/DeviceScannerDaemon/Udev.fs
@@ -4,13 +4,13 @@
 
 module IML.DeviceScannerDaemon.Udev
 
-open Thot.Json.Decode
 open Fable.Core
 open JsInterop
 open IML
 open JsonDecoders
 open StringUtils
 open Fable.Import.Node.PowerPack.Stream
+open Thot.Json.Decode
 
 [<Erase>]
 type DevPath = DevPath of string
@@ -101,24 +101,24 @@ type UEvent =
               } : UEvent)
         |> required "MAJOR" string
         |> required "MINOR" string
-        |> required "DEVLINKS" (andThenSucceed (Option.map (splitSpace >> (Array.map Path))) (option string))
-        |> required "DEVNAME" (andThenSucceed Path string)
-        |> required "DEVPATH" (andThenSucceed DevPath string)
+        |> required "DEVLINKS" (map (Option.map (splitSpace >> (Array.map Path))) (option string))
+        |> required "DEVNAME" (map Path string)
+        |> required "DEVPATH" (map DevPath string)
         |> required "DEVTYPE" string
         |> optional "ID_VENDOR" (option string) None
         |> optional "ID_MODEL" (option string) None
         |> optional "ID_SERIAL" (option string) None
-        |> optional "ID_FS_TYPE" (andThenSucceed (Option.bind emptyStrToNone) (option string)) None
-        |> optional "ID_FS_USAGE" (andThenSucceed (Option.bind emptyStrToNone) (option string)) None
-        |> optional "ID_PART_ENTRY_NUMBER" (andThenSucceed (Option.map Operators.int) (option string)) None
-        |> optional "IML_SIZE" (andThenSucceed (Option.bind emptyStrToNone) (option string)) None
-        |> optional "IML_SCSI_80" (andThenSucceed (Option.map trim) (option string)) None
-        |> optional "IML_SCSI_83" (andThenSucceed (Option.map trim) (option string)) None
-        |> optional "IML_IS_RO" (andThenSucceed (Option.map isOne) (option string)) None
-        |> optional "IML_DM_SLAVE_MMS" (andThenSucceed splitSpace string) [||]
-        |> optional "IML_DM_VG_SIZE" (andThenSucceed (Option.map trim) (option string)) None
+        |> optional "ID_FS_TYPE" (map (Option.bind emptyStrToNone) (option string)) None
+        |> optional "ID_FS_USAGE" (map (Option.bind emptyStrToNone) (option string)) None
+        |> optional "ID_PART_ENTRY_NUMBER" (map (Option.map Operators.int) (option string)) None
+        |> optional "IML_SIZE" (map (Option.bind emptyStrToNone) (option string)) None
+        |> optional "IML_SCSI_80" (map (Option.map trim) (option string)) None
+        |> optional "IML_SCSI_83" (map (Option.map trim) (option string)) None
+        |> optional "IML_IS_RO" (map (Option.map isOne) (option string)) None
+        |> optional "IML_DM_SLAVE_MMS" (map splitSpace string) [||]
+        |> optional "IML_DM_VG_SIZE" (map (Option.map trim) (option string)) None
         |> custom (matchedKeyValuePairs (fun k -> startsWith "MD_DEVICE_" k && endsWith "_DEV" k) string)
-        |> optional "DM_MULTIPATH_DEVICE_PATH" (andThenSucceed (Option.map isOne) (option string)) None
+        |> optional "DM_MULTIPATH_DEVICE_PATH" (map (Option.map isOne) (option string)) None
         |> optional "DM_LV_NAME" (option string) None
         |> optional "DM_VG_NAME" (option string) None
         |> optional "DM_UUID" (option string) None

--- a/IML/DeviceScannerDaemon/Zed.fs
+++ b/IML/DeviceScannerDaemon/Zed.fs
@@ -4,11 +4,11 @@
 
 module IML.DeviceScannerDaemon.Zed
 
-open Thot.Json.Decode
 open Fable.Core
 open IML.JsonDecoders
 open IML.StringUtils
 open Fable.Import.Node.PowerPack.Stream
+open Thot.Json.Decode
 
 [<RequireQualifiedAccess>]
 module Result =
@@ -41,7 +41,7 @@ module Zpool =
 
   let guidDecoder =
     field "ZEVENT_POOL_GUID" string
-      |> andThenSucceed Guid
+      |> map Guid
 
   let isExportState x =
     decodeJson stateStrDecoder x = Ok("EXPORTED")
@@ -110,7 +110,7 @@ module Zfs =
 
   let dsIdDecoder =
     field "ZEVENT_HISTORY_DSID" string
-      |> andThenSucceed Id
+      |> map Id
 
   type Data =
     {
@@ -194,7 +194,7 @@ module Properties =
       (Array.head xs, Array.last xs)
 
     field "ZEVENT_HISTORY_INTERNAL_STR" string
-      |> andThenSucceed (split [| '=' |] >> toTuple)
+      |> map (split [| '=' |] >> toTuple)
 
   let zpoolPropertyDecoder x =
     let decoder =

--- a/IML/JsonDecoders.fs
+++ b/IML/JsonDecoders.fs
@@ -10,5 +10,3 @@ open Fable.Import.Node.PowerPack.Stream
 let decodeJson (decoder: Decoder<'T>) =
     function
       | LineDelimitedJson.Json y -> decodeValue decoder y
-
-let andThenSucceed x y = andThen (x >> succeed) y

--- a/IML/JsonDecodersTest.fs
+++ b/IML/JsonDecodersTest.fs
@@ -13,10 +13,3 @@ let toJson =
 
 test "decodeJson" <| fun () ->
   (decodeJson string (toJson @"""foo""")) == Ok("foo")
-
-test "andThenSucceed" <| fun () ->
-  let decoder =
-    field "bar" string
-      |> andThenSucceed (fun x -> x + "baz")
-
-  JS.JSON.parse """{"bar": "foo"}""" |> decoder == Ok("foobaz")


### PR DESCRIPTION
`andThenSucceed` does the same thing as `Thot.Json.Decode.map`.

Signed-off-by: Joe Grund <joe.grund@intel.com>