### PR TITLE
Update links for Zedlets

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -18,6 +18,11 @@
     <PaketExePath Condition=" '$(PaketExePath)' == '' ">$(PaketToolsPath)paket.exe</PaketExePath>
     <PaketCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
     <PaketCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
+
+    <!-- .net core fdd -->
+    <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
+    <PaketCommand Condition=" '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
+
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>

--- a/IML/DeviceScannerDaemon/Handlers.fs
+++ b/IML/DeviceScannerDaemon/Handlers.fs
@@ -65,8 +65,8 @@ let dataHandler (x:LineDelimitedJson.Json) =
       data.props <- (data.props @ [x])
     | Properties.ZfsProp x ->
       data.props <- (data.props @ [x])
-    | ZedGeneric -> ()
-    | _ ->
-      failwith "Handler got a bad match"
+    | ZedGeneric -> () 
+    | x ->
+      failwithf "Handler got a bad match %A" x
 
   Ok data

--- a/IML/DeviceScannerDaemon/Zed.fs
+++ b/IML/DeviceScannerDaemon/Zed.fs
@@ -114,7 +114,6 @@ module Zfs =
 
   let dsIdDecoder =
     field "ZEVENT_HISTORY_DSID" string
-      |> map Id
 
   type Data =
     {
@@ -136,7 +135,7 @@ module Zfs =
             })
             Zpool.guidDecoder
             (field "ZEVENT_HISTORY_DSNAME" string)
-            dsIdDecoder
+            (dsIdDecoder |> map Id)
         |> decodeJson
 
     decoder x |> unwrap
@@ -224,7 +223,7 @@ module Properties =
           value = value;
         })
         Zpool.guidDecoder
-        Zfs.dsIdDecoder
+        (Zfs.dsIdDecoder |> map Zfs.Id)
         nvpairDecoder
       |> decodeJson
 
@@ -245,8 +244,9 @@ module Properties =
     else
       None
 
-let (|ZedGeneric|_|) x =
+let (|ZedGeneric|_|) x = 
   if decodeJson (field "ZEVENT_EID" string) x |> Result.isOk then
+    printfn "Got generic ZED event %A" x
     Some ()
-  else
-    None
+  else 
+    None 

--- a/IML/DeviceScannerDaemon/Zed.fs
+++ b/IML/DeviceScannerDaemon/Zed.fs
@@ -244,9 +244,9 @@ module Properties =
     else
       None
 
-let (|ZedGeneric|_|) x = 
+let (|ZedGeneric|_|) x =
   if decodeJson (field "ZEVENT_EID" string) x |> Result.isOk then
     printfn "Got generic ZED event %A" x
     Some ()
-  else 
-    None 
+  else
+    None

--- a/IML/DeviceScannerDaemon/__snapshots__/HandlersTest.fs.snap
+++ b/IML/DeviceScannerDaemon/__snapshots__/HandlersTest.fs.snap
@@ -1274,7 +1274,7 @@ Result {
 }
 `;
 
-exports[`Data Handler Should end on a bad match 1`] = `"Handler got a bad match"`;
+exports[`Data Handler Should end on a bad match 1`] = `"Handler got a bad match {}"`;
 
 exports[`Data Handler Should export then import zpool with datasets 1`] = `
 Result {

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,11 @@ Vagrant.configure("2") do |config|
     chmod 777 /lib/udev/event-listener
     cp dist/event-listener/event-listener /usr/libexec/zfs/zed.d/generic-listener.sh
     chmod 755 /usr/libexec/zfs/zed.d/generic-listener.sh
-    ln -sf /usr/libexec/zfs/zed.d/generic-listener.sh /etc/zfs/zed.d/all_event-listener.sh
+    ln -sf /usr/libexec/zfs/zed.d/generic-listener.sh /etc/zfs/zed.d/pool_create-scanner.sh 
+    ln -sf /usr/libexec/zfs/zed.d/generic-listener.sh /etc/zfs/zed.d/pool_destroy-scanner.sh 
+    ln -sf /usr/libexec/zfs/zed.d/generic-listener.sh /etc/zfs/zed.d/pool_import-scanner.sh 
+    ln -sf /usr/libexec/zfs/zed.d/generic-listener.sh /etc/zfs/zed.d/pool_export-scanner.sh 
+    ln -sf /usr/libexec/zfs/zed.d/generic-listener.sh /etc/zfs/zed.d/history_event-scanner.sh 
     cp dist/event-listener/IML/EventListener/udev-rules/99-iml-device-scanner.rules /etc/udev/rules.d/
     cp dist/device-scanner-daemon/IML/DeviceScannerDaemon/systemd-units/* /usr/lib/systemd/system
     systemctl enable device-scanner.socket

--- a/package-lock.json
+++ b/package-lock.json
@@ -3190,7 +3190,7 @@
     "import-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "integrity": "sha1-Xk/9wD9P5sAJxnKb6yljHC+CJ7w=",
       "dev": true,
       "requires": {
         "pkg-dir": "2.0.0",
@@ -5280,6 +5280,12 @@
       "requires": {
         "glob": "7.1.2"
       }
+    },
+    "rollup": {
+      "version": "0.54.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.54.1.tgz",
+      "integrity": "sha512-ebUUgUQ7K/sLn67CtO8Jj8H3RgKAoVWrpiJA7enOkwZPZzTCl8GC8CZ00g5jowjX80KgBmzs4Z1MV6cgglT86A==",
+      "dev": true
     },
     "rollup-plugin-cleanup": {
       "version": "2.0.0",


### PR DESCRIPTION
We are currently emitting every ZED event to the
device-scanner.

Instead we can link each ZEDLET to it's respective
subclass. This will reduce the volume of events
to handle.

Signed-off-by: Joe Grund <joe.grund@intel.com>