### PR TITLE
Update server to use newer LineDelimited stream

### DIFF
--- a/IML.DeviceScannerDaemon/src/Zed.fs
+++ b/IML.DeviceScannerDaemon/src/Zed.fs
@@ -21,6 +21,7 @@ module Zpool =
       /// will change this guid.
       guid: Guid;
       hostName: string;
+      hostId: float option;
       /// The state of the pool.
       state: State;
       /// The size of the pool.
@@ -29,11 +30,12 @@ module Zpool =
       vdev: Libzfs.VDev;
     }
 
-  let create name guid hostName state size vdev =
+  let create name guid hostName hostId state size vdev =
     {
       name = name;
       guid = guid;
-      hostName = hostName
+      hostName = hostName;
+      hostId = hostId;
       state = state;
       size = size;
       vdev = vdev
@@ -139,7 +141,7 @@ module Zed =
 
         let zedPools =
           List.map (fun (x:Libzfs.Pool) ->
-            Zpool.create (ZpoolName x.name) (Guid x.uid) x.hostname (State x.state) x.size x.vdev) libzfsPools
+            Zpool.create (ZpoolName x.name) (Guid x.uid) x.hostname x.hostid (State x.state) x.size x.vdev) libzfsPools
 
         let zedZfs =
           Seq.collect (fun (x:Libzfs.Pool) ->
@@ -157,7 +159,7 @@ module Zed =
         let pool = 
           libzfsInstance.getPoolByName(name)
             |> Option.expect (sprintf "expected pool name %s to exist and be imported." name)
-            |> fun p -> Zpool.create (ZpoolName name) guid p.hostname state p.size p.vdev
+            |> fun p -> Zpool.create (ZpoolName name) guid p.hostname p.hostid state p.size p.vdev
 
         {
           zed with

--- a/iml-device-scanner.spec
+++ b/iml-device-scanner.spec
@@ -20,6 +20,8 @@ Requires: nodejs
 Requires: iml-node-libzfs
 Requires: socat
 
+Obsoletes: %{prefix_name}
+
 %description
 Builds an in-memory representation of devices using udev and zed.
 
@@ -79,9 +81,9 @@ rm -rf %{buildroot}
 %{_sysconfdir}/zfs/zed.d/*.sh
 
 %triggerin -- zfs
+/sbin/modprobe zfs
 systemctl enable zfs-zed.service
 systemctl start zfs-zed.service
-/sbin/modprobe zfs
 echo '{"ZedCommand":"Init"}' | socat - UNIX-CONNECT:/var/run/device-scanner.sock
 
 %post
@@ -102,6 +104,7 @@ fi
 
 %changelog
 * Mon Jan 22 2018 Joe Grund <joe.grund@intel.com> - 2.0.0-1
+- Breaking change, the API has changed output format
 
 
 * Wed Sep 27 2017 Joe Grund <joe.grund@intel.com> - 1.1.1-1

--- a/paket-files/paket.restore.cached
+++ b/paket-files/paket.restore.cached
@@ -31,10 +31,10 @@ NUGET
     Fable.Import.Node (0.4.2)
       Fable.Core (>= 1.3.7) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.2.3) - restriction: >= netstandard2.0
-    Fable.Import.Node.PowerPack (0.5)
-      Fable.Core (>= 1.3.7) - restriction: >= netstandard2.0
-      Fable.Import.Node (>= 0.4) - restriction: >= netstandard2.0
-      Fable.PowerPack (>= 1.3.2) - restriction: >= netstandard2.0
+    Fable.Import.Node.PowerPack (0.6)
+      Fable.Core (>= 1.3.8) - restriction: >= netstandard2.0
+      Fable.Import.Node (>= 0.4.2) - restriction: >= netstandard2.0
+      Fable.PowerPack (>= 1.3.4) - restriction: >= netstandard2.0
     Fable.Import.NodeLibzfs (0.1.9)
       Fable.Core (>= 1.3.8) - restriction: >= netstandard2.0
     Fable.PowerPack (1.3.4)

--- a/paket.lock
+++ b/paket.lock
@@ -31,10 +31,10 @@ NUGET
     Fable.Import.Node (0.4.2)
       Fable.Core (>= 1.3.7) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.2.3) - restriction: >= netstandard2.0
-    Fable.Import.Node.PowerPack (0.5)
-      Fable.Core (>= 1.3.7) - restriction: >= netstandard2.0
-      Fable.Import.Node (>= 0.4) - restriction: >= netstandard2.0
-      Fable.PowerPack (>= 1.3.2) - restriction: >= netstandard2.0
+    Fable.Import.Node.PowerPack (0.6)
+      Fable.Core (>= 1.3.8) - restriction: >= netstandard2.0
+      Fable.Import.Node (>= 0.4.2) - restriction: >= netstandard2.0
+      Fable.PowerPack (>= 1.3.4) - restriction: >= netstandard2.0
     Fable.Import.NodeLibzfs (0.1.9)
       Fable.Core (>= 1.3.8) - restriction: >= netstandard2.0
     Fable.PowerPack (1.3.4)


### PR DESCRIPTION
Update the deviceScannerDaemon server to use
the newer LineDelimited stream. We will
do the parsing in the Main.fs file.

In addition, move the zed service start enable
until after the kernel module has been loaded.

Signed-off-by: Joe Grund <joe.grund@intel.com>