### PR TITLE
Integration Tests - Bail on Failure

### DIFF
--- a/IML.IntegrationTest/test/jest.config.js
+++ b/IML.IntegrationTest/test/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   setupTestFrameworkScriptFile: './jest.setup.js',
   preset: 'jest-fable-preprocessor',
-  displayName: 'Integration tests'
+  displayName: 'Integration tests',
+  bail: true
 };


### PR DESCRIPTION
The integration tests should not continue running if they encounter an
unrecoverable error. They should fail fast so we can determine the issue
quickly.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>