### PR TITLE
Write info command to socket after connecting

### DIFF
--- a/IML.ScannerProxyDaemon/src/Main.fs
+++ b/IML.ScannerProxyDaemon/src/Main.fs
@@ -41,6 +41,11 @@ let sendPostRequest data =
 
 let clientSock = net.connect("/var/run/device-scanner.sock")
 printfn "Connecting to device scanner..."
+
+clientSock
+  |> Writable.write (buffer.Buffer.from "\"Info\"")
+  |> ignore
+
 clientSock
   |> LineDelimited.create()
   |> Readable.onError (fun (e:exn) ->

--- a/IML.ScannerProxyDaemon/src/Main.fs
+++ b/IML.ScannerProxyDaemon/src/Main.fs
@@ -10,7 +10,7 @@ open PowerPack.Stream
 
 open ProxyHandlers
 
-let private libPath x = path.join("var", "lib", "chroma", x)
+let private libPath x = path.join("/var", "lib", "chroma", x)
 
 let private readConfigFile (x) =
   (fs.readFileSync (libPath x)) :> obj

--- a/IML.ScannerProxyDaemon/src/Main.fs
+++ b/IML.ScannerProxyDaemon/src/Main.fs
@@ -43,10 +43,6 @@ let clientSock = net.connect("/var/run/device-scanner.sock")
 printfn "Connecting to device scanner..."
 
 clientSock
-  |> Writable.write (buffer.Buffer.from "\"Info\"")
-  |> ignore
-
-clientSock
   |> LineDelimited.create()
   |> Readable.onError (fun (e:exn) ->
     eprintfn "Unable to parse Json from device scanner %s, %s" e.Message e.StackTrace
@@ -54,3 +50,8 @@ clientSock
   |> map dataHandler
   |> iter sendPostRequest
   |> ignore
+
+clientSock
+  |> Writable.write (buffer.Buffer.from "\"Info\"\n")
+  |> ignore
+

--- a/IML.ScannerProxyDaemon/src/ProxyHandlers.fs
+++ b/IML.ScannerProxyDaemon/src/ProxyHandlers.fs
@@ -35,7 +35,7 @@ let getManagerUrl dirName =
     |> Seq.toList
     |> filterFileName "server"
     |> Seq.map (
-      (fun x -> (fs.readFileSync (dirName + x)).toString())
+      (fun x -> (fs.readFileSync (path.join(dirName, x))).toString())
         >> ofJson<Collections.Map<string,string>>
         >> parseUrl
     )

--- a/iml-device-scanner.spec
+++ b/iml-device-scanner.spec
@@ -101,9 +101,8 @@ echo '{"ZedCommand":"Init"}' | socat - UNIX-CONNECT:/var/run/device-scanner.sock
 if [ $1 -eq 1 ] ; then
   systemctl enable %{base_name}.socket
   systemctl start %{base_name}.socket
-  systemctl enable %{proxy_base_name}.service
-  systemctl start %{proxy_base_name}.service
   udevadm trigger --action=change --subsystem-match=block
+  systemctl enable %{proxy_base_name}.service
 fi
 
 %preun

--- a/iml-device-scanner.spec
+++ b/iml-device-scanner.spec
@@ -102,17 +102,20 @@ if [ $1 -eq 1 ] ; then
   systemctl enable %{base_name}.socket
   systemctl start %{base_name}.socket
   udevadm trigger --action=change --subsystem-match=block
-  systemctl enable %{proxy_base_name}.service
+  systemctl enable %{proxy_base_name}.path
+  systemctl start %{proxy_base_name}.path
 fi
 
 %preun
 if [ $1 -eq 0 ] ; then
+  systemctl stop %{proxy_base_name}.path
+  systemctl disable %{proxy_base_name}.path
   systemctl stop %{proxy_base_name}.service
   systemctl disable %{proxy_base_name}.service
-  systemctl stop %{base_name}.service
-  systemctl disable %{base_name}.service
   systemctl stop %{base_name}.socket
   systemctl disable %{base_name}.socket
+  systemctl stop %{base_name}.service
+  systemctl disable %{base_name}.service
   rm /var/run/%{base_name}.sock
 fi
 


### PR DESCRIPTION
This will enable aggregator to be updated immediately, rather than waiting until host device state changes which updates scanner output and triggers proxy to send to device-aggregator.

Fixes #84 

Signed-off-by: Tom Nabarro <tom.nabarro@outlook.com>