### PR TITLE
Alter triggerin scriptlet for ZFS

### DIFF
--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -113,10 +113,6 @@ rm -rf %{buildroot}
 %attr(0644,root,root)%{_unitdir}/%{proxy_base_name}.path
 
 %triggerin -- zfs >= 0.7.5
-
-/sbin/modprobe zfs
-systemctl enable zfs-zed.service
-systemctl start zfs-zed.service
 echo '{"ZedCommand":"Init"}' | socat - UNIX-CONNECT:/var/run/device-scanner.sock
 
 %post


### PR DESCRIPTION
Alter the scriptlet code that loads the zfs module and starts the zed service.

We will make it a hard requirement that the ZFS kernel
module is loaded and ZED is running prior to installing this
module.

We will do that by installing a service in lustre-ldiskfs-zfs
that does a modprobe.

We will also enforce in monitor mode by enabling ZED in the
install script.

Signed-off-by: Joe Grund <joe.grund@intel.com>