### PR TITLE
Send a SIGHUP when installing / updating device-scanner

### DIFF
--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -113,6 +113,7 @@ rm -rf %{buildroot}
 %attr(0644,root,root)%{_unitdir}/%{proxy_base_name}.path
 
 %triggerin -- zfs >= 0.7.5
+systemctl kill -s SIGHUP zfs-zed.service
 echo '{"ZedCommand":"Init"}' | socat - UNIX-CONNECT:/var/run/device-scanner.sock
 
 %post


### PR DESCRIPTION
Make sure we reconfigure ZED when we change zedlets on
installing / upgrading device-scanner.

Signed-off-by: Joe Grund <joe.grund@intel.com>