### PR TITLE
Udev remove not matching expectation

### DIFF
--- a/IML.DeviceScannerDaemon/src/Udev.fs
+++ b/IML.DeviceScannerDaemon/src/Udev.fs
@@ -100,7 +100,7 @@ type UEvent =
               } : UEvent)
         |> required "MAJOR" string
         |> required "MINOR" string
-        |> required "DEVLINKS" (map (Option.map (splitSpace >> (Array.map Path))) (option string))
+        |> optional "DEVLINKS" (map (Option.map (splitSpace >> (Array.map Path))) (option string)) None
         |> required "DEVNAME" (map Path string)
         |> required "DEVPATH" (map DevPath string)
         |> required "DEVTYPE" string
@@ -124,9 +124,8 @@ type UEvent =
         |> optional "MD_UUID" (option string) None
 
 let uEventDecoder x =
-  match decodeString UEvent.Decoder x with
-    | Ok y -> Ok y
-    | Error y -> Error (exn y)
+  decodeString UEvent.Decoder x
+    |> Result.mapError exn
 
 type BlockDevices = Map<DevPath, UEvent>
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ SHELL
 
 Vagrant.configure("2") do |config|
   config.vm.box = "manager-for-lustre/centos74-1708-base"
-  config.vm.synced_folder ".", "/vagrant"
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
   config.vm.boot_timeout = 600
   config.ssh.username = 'root'
   config.ssh.password = 'vagrant'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ SHELL
 
 Vagrant.configure("2") do |config|
   config.vm.box = "manager-for-lustre/centos74-1708-base"
-  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+  config.vm.synced_folder ".", "/vagrant"
   config.vm.boot_timeout = 600
   config.ssh.username = 'root'
   config.ssh.password = 'vagrant'

--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -112,7 +112,7 @@ rm -rf %{buildroot}
 %attr(0644,root,root)%{_unitdir}/%{proxy_base_name}.service
 %attr(0644,root,root)%{_unitdir}/%{proxy_base_name}.path
 
-%triggerin -- zfs >= 0.7.5
+%triggerin -- zfs > 0.7.4
 systemctl kill -s SIGHUP zfs-zed.service
 echo '{"ZedCommand":"Init"}' | socat - UNIX-CONNECT:/var/run/device-scanner.sock
 


### PR DESCRIPTION
Fixes #103.

`DEVLINKS` may not exist when `Add` or `Remove` fires.
As such make the field optional in the parser.

Signed-off-by: Joe Grund <joe.grund@intel.com>