### PR TITLE
Stop aggregator package from requiring device-scanner

### DIFF
--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -46,7 +46,6 @@ scanner-proxy-daemon forwards device-scanner updates received
 Summary:    Assembles global device view from multiple device scanner instances.
 License:    MIT
 Group:      System Environment/Libraries
-Requires:   %{base_prefixed} = %{version}-%{release}
 %description aggregator
 device-aggregator-daemon aggregates data received from device
 scanner instances over HTTPS.


### PR DESCRIPTION
The aggregator sub package of the `device-scanner` project should not require the device-scanner package itself.

Signed-off-by: Tom Nabarro <tom.nabarro@outlook.com>