### PR TITLE
Update spec and units

### DIFF
--- a/IML.DeviceAggregatorDaemon/systemd-units/99-device-aggregator.preset
+++ b/IML.DeviceAggregatorDaemon/systemd-units/99-device-aggregator.preset
@@ -1,0 +1,2 @@
+enable device-aggregator.socket
+enable device-aggregator.service

--- a/IML.DeviceAggregatorDaemon/systemd-units/device-aggregator.service
+++ b/IML.DeviceAggregatorDaemon/systemd-units/device-aggregator.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Device Aggregator Daemon
 RefuseManualStart=true
+BindsTo=device-scanner.socket
 
 [Service]
 Restart=always

--- a/IML.DeviceScannerDaemon/systemd-units/99-device-scanner.preset
+++ b/IML.DeviceScannerDaemon/systemd-units/99-device-scanner.preset
@@ -1,0 +1,3 @@
+enable device-scanner.service
+enable device-scanner.socket
+enable mount-emitter.service

--- a/IML.DeviceScannerDaemon/systemd-units/device-scanner.service
+++ b/IML.DeviceScannerDaemon/systemd-units/device-scanner.service
@@ -2,11 +2,12 @@
 Description=IML Device Scanner Daemon
 RefuseManualStart=true
 DefaultDependencies=false
+BindsTo=device-scanner.socket
 
 [Service]
 Restart=always
 Environment=NODE_ENV=production
 Environment=NODE_PATH=/usr/lib/node_modules
 ExecStart=/usr/bin/node /usr/lib64/iml-device-scanner-daemon/device-scanner-daemon
-StandardOutput=journal+console
-StandardError=journal+console
+StandardOutput=journal
+StandardError=journal

--- a/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
+++ b/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=IML Mount Emitter
+PartOf=device-scanner.socket
 
 [Service]
 Restart=always

--- a/IML.ScannerProxyDaemon/systemd-units/99-scanner-proxy.preset
+++ b/IML.ScannerProxyDaemon/systemd-units/99-scanner-proxy.preset
@@ -1,0 +1,2 @@
+enable scanner-proxy.path
+enable scanner-proxy.service

--- a/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.service
+++ b/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.service
@@ -2,6 +2,7 @@
 Description=IML Scanner Proxy Daemon
 Requires=device-scanner.service
 After=device-scanner.service
+BindsTo=scanner-proxy.path
 
 [Service]
 Restart=always

--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -151,7 +151,7 @@ rm -rf %{buildroot}
 %attr(0644,root,root)%{_presetdir}/99-%{aggregator_name}.preset
 
 %triggerin -- zfs > 0.7.4
-if [modprobe zfs -eq 0]; then
+if modprobe zfs; then
   systemctl enable zfs-zed.service
   systemctl start zfs-zed.service
   systemctl kill -s SIGHUP zfs-zed.service

--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -184,6 +184,7 @@ fi
 
 %preun
 %systemd_preun %{base_name}.socket
+%systemd_preun %{base_name}.service
 
 if [ $1 -eq 0 ]; then
   rm /var/run/%{base_name}.sock
@@ -191,9 +192,11 @@ fi
 
 %preun proxy
 %systemd_preun %{proxy_name}.path
+%systemd_preun %{proxy_name}.service
 
 %preun aggregator
 %systemd_preun %{aggregator_name}.socket
+%systemd_preun %{aggregator_name}.service
 
 if [ $1 -eq 0 ] ; then
   rm /var/run/%{aggregator_name}.sock

--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -24,6 +24,8 @@ BuildRequires: nodejs
 BuildRequires: npm
 BuildRequires: mono-devel
 BuildRequires: %{?scl_prefix}rh-dotnet20
+
+%{?systemd_requires}
 BuildRequires: systemd
 
 Requires: nodejs
@@ -65,12 +67,16 @@ EOF
 
 %install
 mkdir -p %{buildroot}%{_unitdir}
+mkdir -p %{buildroot}%{_presetdir}
 cp dist/%{base_name}-daemon/%{base_name}.socket %{buildroot}%{_unitdir}
 cp dist/%{base_name}-daemon/%{base_name}.service %{buildroot}%{_unitdir}
+cp dist/%{base_name}-daemon/99-%{base_name}.preset %{buildroot}%{_presetdir}
 cp dist/%{proxy_name}-daemon/%{proxy_name}.service %{buildroot}%{_unitdir}
 cp dist/%{proxy_name}-daemon/%{proxy_name}.path %{buildroot}%{_unitdir}
+cp dist/%{proxy_name}-daemon/99-%{proxy_name}.preset %{buildroot}%{_presetdir}
 cp dist/%{aggregator_name}-daemon/%{aggregator_name}.socket %{buildroot}%{_unitdir}
 cp dist/%{aggregator_name}-daemon/%{aggregator_name}.service %{buildroot}%{_unitdir}
+cp dist/%{aggregator_name}-daemon/99-%{aggregator_name}.preset %{buildroot}%{_presetdir}
 cp dist/listeners/%{mount_name}.service %{buildroot}%{_unitdir}
 
 mkdir -p %{buildroot}%{_libdir}/%{base_prefixed}-daemon
@@ -116,6 +122,7 @@ rm -rf %{buildroot}
 %attr(0755,root,root)%{_libdir}/%{base_prefixed}-daemon/%{base_name}-daemon
 %attr(0644,root,root)%{_unitdir}/%{base_name}.service
 %attr(0644,root,root)%{_unitdir}/%{base_name}.socket
+%attr(0644,root,root)%{_presetdir}/99-%{base_name}.preset
 %dir %{_libdir}/%{mount_prefixed}
 %attr(0755,root,root)%{_libdir}/%{mount_prefixed}/%{mount_name}
 %attr(0644,root,root)%{_unitdir}/%{mount_name}.service
@@ -134,88 +141,77 @@ rm -rf %{buildroot}
 %attr(0755,root,root)%{_libdir}/%{proxy_prefixed}-daemon/%{proxy_name}-daemon
 %attr(0644,root,root)%{_unitdir}/%{proxy_name}.service
 %attr(0644,root,root)%{_unitdir}/%{proxy_name}.path
+%attr(0644,root,root)%{_presetdir}/99-%{proxy_name}.preset
 
 %files aggregator
 %dir %{_libdir}/%{aggregator_prefixed}-daemon
 %attr(0755,root,root)%{_libdir}/%{aggregator_prefixed}-daemon/%{aggregator_name}-daemon
 %attr(0644,root,root)%{_unitdir}/%{aggregator_name}.service
 %attr(0644,root,root)%{_unitdir}/%{aggregator_name}.socket
+%attr(0644,root,root)%{_presetdir}/99-%{aggregator_name}.preset
 
 %triggerin -- zfs > 0.7.4
-modprobe zfs
-systemctl enable zfs-zed.service
-systemctl start zfs-zed.service
-systemctl kill -s SIGHUP zfs-zed.service
-echo '{"ZedCommand":"Init"}' | socat - UNIX-CONNECT:/var/run/%{base_name}.sock
-
-%post
-if [ $1 -eq 1 ]; then
-  systemctl enable %{base_name}.socket
-  systemctl start %{base_name}.socket
-  udevadm trigger --action=change --subsystem-match=block
-  systemctl enable %{mount_name}.service
-  systemctl start %{mount_name}.service
-elif [ $1 -eq 2 ]; then
-  systemctl daemon-reload
-  systemctl stop %{mount_name}.service
-  systemctl stop %{base_name}.socket
-  systemctl stop %{base_name}.service
-  systemctl start %{base_name}.socket
-  udevadm trigger --action=change --subsystem-match=block
-  systemctl start %{mount_name}.service
+if [modprobe zfs -eq 0]; then
+  systemctl enable zfs-zed.service
+  systemctl start zfs-zed.service
+  systemctl kill -s SIGHUP zfs-zed.service
+  echo '{"ZedCommand":"Init"}' | socat - UNIX-CONNECT:/var/run/%{base_name}.sock
 fi
 
-%post aggregator
+%post
+%systemd_post %{base_name}.socket
+%systemd_post %{base_name}.service
+%systemd_post %{mount_name}.service
+
 if [ $1 -eq 1 ]; then
-  systemctl enable %{aggregator_name}.socket
-  systemctl start %{aggregator_name}.socket
-elif [ $1 -eq 2 ]; then
-  systemctl daemon-reload
-  systemctl stop %{aggregator_name}.socket
-  systemctl stop %{aggregator_name}.service
-  systemctl start %{aggregator_name}.socket
+  systemctl start %{base_name}.socket
+  udevadm trigger --action=change --subsystem-match=block
 fi
 
 %post proxy
-if [ $1 -eq 1 ]; then
-  systemctl enable %{proxy_name}.path
-  systemctl start %{proxy_name}.path
-elif [ $1 -eq 2 ]; then
-  systemctl daemon-reload
-  systemctl stop %{proxy_name}.service
+%systemd_post %{proxy_name}.path
 
-  if [ -f "/var/lib/chroma/settings" ]; then
-    touch /var/lib/chroma/settings
-  fi
+if [ $1 -eq 1 ]; then
+  systemctl start %{proxy_name}.path
+fi
+
+%post aggregator
+%systemd_post %{aggregator_name}.socket
+
+if [ $1 -eq 1 ]; then
+  systemctl start %{aggregator_name}.socket
 fi
 
 %preun
+%systemd_preun %{base_name}.socket
+
 if [ $1 -eq 0 ]; then
-  systemctl stop %{mount_name}.service
-  systemctl disable %{mount_name}.socket
-  systemctl stop %{base_name}.socket
-  systemctl disable %{base_name}.socket
-  systemctl stop %{base_name}.service
-  systemctl disable %{base_name}.service
   rm /var/run/%{base_name}.sock
 fi
 
 %preun proxy
-if [ $1 -eq 0 ]; then
-  systemctl stop %{proxy_name}.path
-  systemctl disable %{proxy_name}.path
-  systemctl stop %{proxy_name}.service
-  systemctl disable %{proxy_name}.service
-fi
+%systemd_preun %{proxy_name}.path
 
 %preun aggregator
+%systemd_preun %{aggregator_name}.socket
+
 if [ $1 -eq 0 ] ; then
-  systemctl stop %{aggregator_name}.socket
-  systemctl disable %{aggregator_name}.socket
-  systemctl stop %{aggregator_name}.service
-  systemctl disable %{aggregator_name}.service
   rm /var/run/%{aggregator_name}.sock
 fi
+
+%postun
+%systemd_postun_with_restart %{base_name}.socket
+
+if [ $1 -ge 1 ] ; then
+  udevadm trigger --action=change --subsystem-match=block
+  systemctl start %{mount_name}.service
+fi
+
+%postun proxy
+%systemd_postun_with_restart %{proxy_name}.path
+
+%postun aggregator
+%systemd_postun_with_restart %{aggregator_name}.socket
 
 %changelog
 * Mon Feb 26 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.1.0-2


### PR DESCRIPTION
Update the device-scanner.spec to utilize systemd macros.
In addition, create presets for each service, and bind the
services to the socket / paths so they stop / restart when they
should.

Signed-off-by: Joe Grund <joe.grund@intel.com>