### PR TITLE
Fix lvcreate hangs

### DIFF
--- a/IML.Listeners/UdevListener/udev-rules/99-iml-device-scanner.rules
+++ b/IML.Listeners/UdevListener/udev-rules/99-iml-device-scanner.rules
@@ -17,7 +17,7 @@ ACTION=="add|change", ENV{DM_UUID}=="?*", PROGRAM="/bin/bash -c 'for l in `ls /s
 ACTION=="add|change", ENV{DM_UUID}=="mpath-?*", ENV{IML_IS_MPATH}="1"
 
 # Get vgs size (not readily available from other udev output)
-ACTION=="add|change", ENV{DM_VG_NAME}=="?*", PROGRAM="/usr/sbin/vgs --no-headings --units b -o size $env{DM_VG_NAME}", RESULT=="?*", ENV{IML_DM_VG_SIZE}="$result"
+ACTION=="add|change", ENV{DM_VG_NAME}=="?*", PROGRAM="/usr/sbin/vgs --readonly --no-headings --units b -o size $env{DM_VG_NAME}", RESULT=="?*", ENV{IML_DM_VG_SIZE}="$result"
 
 # Get ro state whenever there is an add or change on the device
 ACTION=="add|change", PROGRAM="/sbin/blockdev --getro $devnode", RESULT=="?*", ENV{IML_IS_RO}="$result"


### PR DESCRIPTION
There is a very reproducible race when trying to read size out with `vgs` during a lvcreate.

It seems like this can be avoided by using the --readonly flag.

Signed-off-by: Joe Grund <joe.grund@intel.com>