### PR TITLE
Implement service-grouping for device-scanner.

### DIFF
--- a/IML.DeviceScannerDaemon/systemd-units/device-scanner.service
+++ b/IML.DeviceScannerDaemon/systemd-units/device-scanner.service
@@ -2,7 +2,9 @@
 Description=IML Device Scanner Daemon
 RefuseManualStart=true
 DefaultDependencies=false
+Requires=device-scanner.socket
 BindsTo=device-scanner.socket
+After=device-scanner.socket
 OnFailure=block-device-populator.service zed-populator.service
 
 [Service]

--- a/IML.DeviceScannerDaemon/systemd-units/device-scanner.socket
+++ b/IML.DeviceScannerDaemon/systemd-units/device-scanner.socket
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Device Scanner Socket
 DefaultDependencies=false
+PartOf=device-scanner.target
 
 [Socket]
 ListenStream=/var/run/device-scanner.sock
@@ -8,3 +9,4 @@ RemoveOnStop=true
 
 [Install]
 WantedBy=sockets.target
+WantedBy=device-scanner.target

--- a/IML.DeviceScannerDaemon/systemd-units/device-scanner.target
+++ b/IML.DeviceScannerDaemon/systemd-units/device-scanner.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=Device Scanner Services
+
+Requires=block-device-populator.service
+Requires=zed-populator.service

--- a/IML.DeviceScannerDaemon/systemd-units/zed-populator.service
+++ b/IML.DeviceScannerDaemon/systemd-units/zed-populator.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=IML ZED Populator
 
-
 [Service]
 Type=oneshot
 ExecStart=/bin/bash -c 'if /usr/sbin/udevadm info --path=/module/zfs; then echo \'{"ZedCommand":"Init"}\' | socat - UNIX-CONNECT:/var/run/device-scanner.sock; fi'

--- a/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
+++ b/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=IML Mount Emitter
-PartOf=device-scanner.socket
 After=device-scanner.socket
 
 [Service]

--- a/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
+++ b/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
@@ -7,7 +7,7 @@ After=device-scanner.socket
 Restart=always
 Environment=NODE_ENV=production
 ExecStartPre=/bin/bash -c 'exec /usr/bin/findmnt -P | /usr/lib64/iml-mount-emitter/mount-emitter'
-ExecStart=/bin/bash -c 'exec /usr/bin/stdbuf -o L /usr/bin/findmnt --poll -P -o ACTION,TARGET,SOURCE,FSTYPE,OPTIONS,OLD-TARGET,OLD-OPTIONS | /usr/lib64/iml-mo
+ExecStart=/bin/bash -c 'exec /usr/bin/stdbuf -o L /usr/bin/findmnt --poll -P -o ACTION,TARGET,SOURCE,FSTYPE,OPTIONS,OLD-TARGET,OLD-OPTIONS | /usr/lib64/iml-mount-emitter/mount-emitter'
 StandardOutput=journal
 StandardError=journal
 

--- a/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
+++ b/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
@@ -1,14 +1,15 @@
 [Unit]
 Description=IML Mount Emitter
+PartOf=device-scanner.socket
 After=device-scanner.socket
 
 [Service]
 Restart=always
 Environment=NODE_ENV=production
 ExecStartPre=/bin/bash -c 'exec /usr/bin/findmnt -P | /usr/lib64/iml-mount-emitter/mount-emitter'
-ExecStart=/bin/bash -c 'exec /usr/bin/stdbuf -o L /usr/bin/findmnt --poll -P -o ACTION,TARGET,SOURCE,FSTYPE,OPTIONS,OLD-TARGET,OLD-OPTIONS | /usr/lib64/iml-mount-emitter/mount-emitter'
+ExecStart=/bin/bash -c 'exec /usr/bin/stdbuf -o L /usr/bin/findmnt --poll -P -o ACTION,TARGET,SOURCE,FSTYPE,OPTIONS,OLD-TARGET,OLD-OPTIONS | /usr/lib64/iml-mo
 StandardOutput=journal
 StandardError=journal
 
 [Install]
-WantedBy=default.target
+WantedBy=device-scanner.socket

--- a/IML.Listeners/MountEmitter/systemd-units/swap-emitter.timer
+++ b/IML.Listeners/MountEmitter/systemd-units/swap-emitter.timer
@@ -1,10 +1,11 @@
 [Unit]
 Description=IML Swap Emitter Timer
 After=device-scanner.socket
+PartOf=device-scanner.socket
 
 [Timer]
 OnUnitActiveSec=60
 OnStartupSec=0
 
 [Install]
-WantedBy=default.target
+WantedBy=device-scanner.socket

--- a/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.path
+++ b/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.path
@@ -1,8 +1,10 @@
 [Unit]
 Description=IML Scanner Proxy Path
+PartOf=device-scanner.socket
+After=device-scanner.socket
 
 [Path]
 DirectoryNotEmpty=/var/lib/chroma/settings
 
 [Install]
-WantedBy=default.target
+WantedBy=device-scanner.socket

--- a/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.service
+++ b/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.service
@@ -2,8 +2,9 @@
 Description=IML Scanner Proxy Daemon
 RefuseManualStart=true
 Requires=device-scanner.socket
-After=device-scanner.service
+After=device-scanner.socket
 PartOf=scanner-proxy.path
+After=scanner-proxy.path
 
 [Service]
 Restart=always

--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -70,6 +70,7 @@ EOF
 %install
 mkdir -p %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_presetdir}
+cp dist/%{base_name}-daemon/%{base_name}.target %{buildroot}%{_unitdir}
 cp dist/%{base_name}-daemon/%{base_name}.socket %{buildroot}%{_unitdir}
 cp dist/%{base_name}-daemon/%{base_name}.service %{buildroot}%{_unitdir}
 cp dist/%{base_name}-daemon/block-device-populator.service %{buildroot}%{_unitdir}
@@ -131,6 +132,7 @@ rm -rf %{buildroot}
 %attr(0644,root,root)%{_unitdir}/zed-populator.service
 %attr(0644,root,root)%{_unitdir}/swap-emitter.timer
 %attr(0644,root,root)%{_unitdir}/swap-emitter.service
+%attr(0644,root,root)%{_unitdir}/%{base_name}.target
 %attr(0644,root,root)%{_unitdir}/%{base_name}.service
 %attr(0644,root,root)%{_unitdir}/%{base_name}.socket
 %attr(0644,root,root)%{_presetdir}/00-%{base_name}.preset
@@ -197,6 +199,7 @@ if [ $1 -eq 1 ]; then
 fi
 
 %preun
+%systemd_preun %{base_name}.target
 %systemd_preun %{base_name}.socket
 %systemd_preun %{base_name}.service
 %systemd_preun %{mount_name}.service

--- a/paket-files/paket.restore.cached
+++ b/paket-files/paket.restore.cached
@@ -103,7 +103,7 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.1
       System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.1
       System.Threading (>= 4.3) - restriction: >= netstandard1.1
-    Microsoft.Net.Compilers (2.8) - restriction: >= netcoreapp2.0
+    Microsoft.Net.Compilers (2.8) - restriction: || (>= net45) (>= netcoreapp2.0)
     Microsoft.NETCore.App (2.0.7) - restriction: >= netcoreapp2.0
       Microsoft.NETCore.DotNetHostPolicy (>= 2.0.7) - restriction: >= netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 2.0.2) - restriction: >= netcoreapp2.0

--- a/paket.lock
+++ b/paket.lock
@@ -103,7 +103,7 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.1
       System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.1
       System.Threading (>= 4.3) - restriction: >= netstandard1.1
-    Microsoft.Net.Compilers (2.8) - restriction: >= netcoreapp2.0
+    Microsoft.Net.Compilers (2.8) - restriction: || (>= net45) (>= netcoreapp2.0)
     Microsoft.NETCore.App (2.0.7) - restriction: >= netcoreapp2.0
       Microsoft.NETCore.DotNetHostPolicy (>= 2.0.7) - restriction: >= netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 2.0.2) - restriction: >= netcoreapp2.0


### PR DESCRIPTION
Update most units so they are explicit in their dependency on
device-scanner.socket. In addition, create a device-scanner.target

We can start all services by running:

`systemctl start device-scanner.target`

and stop all units:

`systemctl stop device-scanner.target`

Starting using device-scanner.target will also
trigger some oneshot scripts to populate.

Signed-off-by: Joe Grund <joe.grund@intel.com>