### PR TITLE
Extract mount-emitter ExecStartPre

### DIFF
--- a/IML.DeviceScannerDaemon/systemd-units/00-device-scanner.preset
+++ b/IML.DeviceScannerDaemon/systemd-units/00-device-scanner.preset
@@ -1,5 +1,3 @@
 enable device-scanner.*
 enable mount-emitter.service
 enable swap-emitter.*
-enable block-device-populator.service
-enable zed-populator.service

--- a/IML.DeviceScannerDaemon/systemd-units/device-scanner.service
+++ b/IML.DeviceScannerDaemon/systemd-units/device-scanner.service
@@ -5,7 +5,7 @@ DefaultDependencies=false
 Requires=device-scanner.socket
 BindsTo=device-scanner.socket
 After=device-scanner.socket
-OnFailure=block-device-populator.service zed-populator.service
+OnFailure=block-device-populator.service zed-populator.service mount-populator.service
 
 [Service]
 Restart=always

--- a/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
+++ b/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
@@ -2,11 +2,12 @@
 Description=IML Mount Emitter
 PartOf=device-scanner.socket
 After=device-scanner.socket
+Requires=mount-populator.service
+After=mount-populator.service
 
 [Service]
 Restart=always
 Environment=NODE_ENV=production
-ExecStartPre=/bin/bash -c 'exec /usr/bin/findmnt -P | /usr/lib64/iml-mount-emitter/mount-emitter'
 ExecStart=/bin/bash -c 'exec /usr/bin/stdbuf -o L /usr/bin/findmnt --poll -P -o ACTION,TARGET,SOURCE,FSTYPE,OPTIONS,OLD-TARGET,OLD-OPTIONS | /usr/lib64/iml-mount-emitter/mount-emitter'
 StandardOutput=journal
 StandardError=journal

--- a/IML.Listeners/MountEmitter/systemd-units/mount-populator.service
+++ b/IML.Listeners/MountEmitter/systemd-units/mount-populator.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=IML Mount Populator
+
+[Service]
+ExecStart=/bin/bash -c 'exec /usr/bin/findmnt -P | /usr/lib64/iml-mount-emitter/mount-emitter'
+Type=oneshot

--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -83,6 +83,7 @@ cp dist/%{aggregator_name}-daemon/%{aggregator_name}.socket %{buildroot}%{_unitd
 cp dist/%{aggregator_name}-daemon/%{aggregator_name}.service %{buildroot}%{_unitdir}
 cp dist/%{aggregator_name}-daemon/00-%{aggregator_name}.preset %{buildroot}%{_presetdir}
 cp dist/listeners/%{mount_name}.service %{buildroot}%{_unitdir}
+cp dist/listeners/mount-populator.service %{buildroot}%{_unitdir}
 cp dist/listeners/swap-emitter.timer %{buildroot}%{_unitdir}
 cp dist/listeners/swap-emitter.service %{buildroot}%{_unitdir}
 
@@ -130,6 +131,7 @@ rm -rf %{buildroot}
 %attr(0755,root,root)%{_libdir}/%{base_prefixed}-daemon/%{base_name}-daemon
 %attr(0644,root,root)%{_unitdir}/block-device-populator.service
 %attr(0644,root,root)%{_unitdir}/zed-populator.service
+%attr(0644,root,root)%{_unitdir}/mount-populator.service
 %attr(0644,root,root)%{_unitdir}/swap-emitter.timer
 %attr(0644,root,root)%{_unitdir}/swap-emitter.service
 %attr(0644,root,root)%{_unitdir}/%{base_name}.target
@@ -205,6 +207,7 @@ fi
 %systemd_preun %{mount_name}.service
 %systemd_preun block-device-populator.service
 %systemd_preun zed-populator.service
+%systemd_preun mount-populator.service
 %systemd_preun swap-emitter.timer
 %systemd_preun swap-emitter.service
 


### PR DESCRIPTION
If device-scanner fails unexpectedly, it needs to be
repopulated with mounts.

This wasn't happening because initial mount population was tied into
mount-emitter.service.

Extract initial mount population to mount-populator.service, so
device-scanner can use it OnFailure.

Signed-off-by: Joe Grund <joe.grund@intel.com>