### PR TITLE
Send FIN when readable side ends

### DIFF
--- a/IML.DeviceScannerDaemon/src/Connections.fs
+++ b/IML.DeviceScannerDaemon/src/Connections.fs
@@ -29,7 +29,10 @@ let createConn connection command =
       | Command.Stream ->
         let conn = Stream connection
 
-        Readable.onEnd (fun () -> removeConn conn) connection
+        Readable.onEnd (fun () ->
+          connection.``end``()
+          removeConn conn
+        ) connection
           |> ignore
 
         conn


### PR DESCRIPTION
We are currently using `allowHalfOpen` when creating a net.socket.
Because of this we need to explicitly close the device-scanner
side of the socket when the consumer side closes.

We are not doing this at the moment, and we can see a ton of ESTAB
connections because of it.

Signed-off-by: Joe Grund <joe.grund@intel.com>