### PR TITLE
Do not start scanner-proxy until server file exists.

### DIFF
--- a/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.path
+++ b/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.path
@@ -3,7 +3,7 @@ Description=IML Scanner Proxy Path
 PartOf=device-scanner.socket
 
 [Path]
-DirectoryNotEmpty=/var/lib/chroma/settings
+PathExists=/var/lib/chroma/settings/c2VydmVy
 
 [Install]
 WantedBy=device-scanner.socket


### PR DESCRIPTION
We currently pend on the /var/lib/chroma/settings dir existing.

This is too racy, as the certs are written there before
the server file is.

The scanner-proxy will start a few times in that gap and immediately
fail because the file is missing.

Switch to looking for the entire server path.

Signed-off-by: Joe Grund <joe.grund@intel.com>
