### PR TITLE
Account for local mounts using uuid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ node_modules
 *.userprefs
 *.tgz
 *.rpm
-.vscode
 .vagrant
 .idea
 dist

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "fantomas",
+            "type": "shell",
+            "command": "dotnet fantomas ${file}"
+        }
+    ]
+}

--- a/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
+++ b/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
@@ -9,7 +9,7 @@ After=mount-populator.service
 [Service]
 Restart=always
 Environment=NODE_ENV=production
-ExecStart=/bin/bash -c 'exec /usr/bin/stdbuf -o L /usr/bin/findmnt --poll -P -o ACTION,TARGET,SOURCE,FSTYPE,OPTIONS,OLD-TARGET,OLD-OPTIONS | /usr/lib64/iml-mount-emitter/mount-emitter'
+ExecStart=/bin/bash -c 'exec /usr/bin/stdbuf -o L /usr/bin/findmnt --poll -P -e -o ACTION,TARGET,SOURCE,FSTYPE,OPTIONS,OLD-TARGET,OLD-OPTIONS | /usr/lib64/iml-mount-emitter/mount-emitter'
 StandardOutput=journal
 StandardError=journal
 

--- a/IML.Listeners/MountEmitter/systemd-units/mount-populator.service
+++ b/IML.Listeners/MountEmitter/systemd-units/mount-populator.service
@@ -3,5 +3,5 @@ Description=IML Mount Populator
 After=device-scanner.socket
 
 [Service]
-ExecStart=/bin/bash -c 'exec /usr/bin/findmnt -P | /usr/lib64/iml-mount-emitter/mount-emitter'
+ExecStart=/bin/bash -c 'exec /usr/bin/findmnt -P -e | /usr/lib64/iml-mount-emitter/mount-emitter'
 Type=oneshot

--- a/IML.Listeners/MountEmitter/systemd-units/swap-emitter.service
+++ b/IML.Listeners/MountEmitter/systemd-units/swap-emitter.service
@@ -2,5 +2,5 @@
 Description=IML Swap Emitter
 
 [Service]
-ExecStart=/bin/bash -c 'exec /usr/bin/findmnt -P -s -t swap | /usr/lib64/iml-mount-emitter/mount-emitter'
+ExecStart=/bin/bash -c 'exec /usr/bin/findmnt -P -s -e -t swap | /usr/lib64/iml-mount-emitter/mount-emitter'
 Type=oneshot


### PR DESCRIPTION
Fixes #186

Utilize the -e flag with findmnt to evaluate tags to device names.

That way, if a mount is created using a tag, it will be converted to a device name.

Signed-off-by: Joe Grund <joe.grund@intel.com>
