### PR TITLE
Stop aggregator when stopping manager.target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ results.xml
 travis_env
 include/copr-mfl
 jest_0
+.paket/Paket.Restore.targets

--- a/IML.DeviceAggregatorDaemon/systemd-units/device-aggregator.socket
+++ b/IML.DeviceAggregatorDaemon/systemd-units/device-aggregator.socket
@@ -1,5 +1,6 @@
 [Unit]
 Description=IML Device Aggregator Socket
+PartOf=iml-manager.target
 
 [Socket]
 ListenStream=/var/run/device-aggregator.sock


### PR DESCRIPTION
Now that we have a manager.target to hook into,
we can stop the aggregator when the manager stops
by marking it as part of the manager.target.

Signed-off-by: Joe Grund <joe.grund@intel.com>