### PR TITLE
Use module-tools to build

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,16 @@
+srpm:
+
+	rpm --import https://packages.microsoft.com/keys/microsoft.asc
+	rpm -Uvh https://packages.microsoft.com/config/fedora/27/prod.repo
+	dnf repolist
+	dnf search dotnet
+	dnf -y -v install nodejs aspnetcore-runtime-2.1
+	curl -o /tmp/cacert.pem https://curl.haxx.se/ca/cacert.pem
+	cert-sync --user /tmp/cacert.pem
+	npm i --ignore-scripts
+	export DOTNET_CLI_TELEMETRY_OPTOUT=1
+	npm run restore
+	dotnet fable npm-build
+	npm pack
+
+	rpmbuild -bs --define epel\ 1 --define _srcrpmdir\ ${CURDIR} --define _sourcedir\ ${CURDIR} --define _rpmdir\ ${outdir} ${spec}

--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -1,3 +1,5 @@
+%{?!package_release: %global package_release 1}
+
 %define     base_name device-scanner
 %define     proxy_name scanner-proxy
 %define     mount_name mount-emitter
@@ -7,8 +9,8 @@
 %define     mount_prefixed iml-%{mount_name}
 %define     aggregator_prefixed iml-%{aggregator_name}
 Name:       %{base_prefixed}
-Version:    2.0.0
-Release:    1%{?dist}
+Version:    2.2.0
+Release:    %{package_release}%{?dist}
 Summary:    Maintains data of block and ZFS devices
 License:    MIT
 Group:      System Environment/Libraries
@@ -18,12 +20,6 @@ URL:        https://github.com/intel-hpdd/%{base_name}
 Source0:    %{base_prefixed}-%{version}.tgz
 
 ExclusiveArch: %{nodejs_arches}
-
-BuildRequires: nodejs-packaging
-BuildRequires: nodejs
-BuildRequires: npm
-BuildRequires: mono-devel
-BuildRequires: %{?scl_prefix}rh-dotnet20
 
 %{?systemd_requires}
 BuildRequires: systemd
@@ -55,17 +51,10 @@ device-aggregator-daemon aggregates data received from device
 scanner instances over HTTPS.
 
 %prep
-%setup
+%setup -q -n package
 
 %build
-cert-sync /etc/pki/tls/certs/ca-bundle.crt
-scl enable rh-dotnet20 - << EOF
-set -e
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-npm i --ignore-scripts
-npm run restore
-dotnet fable npm-build
-EOF
+#nothing to do
 
 %install
 mkdir -p %{buildroot}%{_unitdir}
@@ -234,16 +223,16 @@ fi
 %systemd_postun_with_restart %{aggregator_name}.socket
 
 %changelog
-* Mon May 14 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.1.1-1
+* Mon May 14 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.0.0-1
 - Add mount detection to device-scanner
 - Integrate device-aggregator
 - Move device munging inside aggregator
 
-* Mon Feb 26 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.1.0-2
+* Mon Feb 26 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.0.0-1
 - Make scanner-proxy a sub-package (separate rpm)
 - Handle upgrade scenarios
 
-* Thu Feb 15 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.1.0-1
+* Thu Feb 15 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.0.0-1
 - Minor change, integrate scanner-proxy project
 
 * Mon Jan 22 2018 Joe Grund <joe.grund@intel.com> - 2.0.0-1

--- a/mock-build.sh
+++ b/mock-build.sh
@@ -1,41 +1,15 @@
 #!/bin/bash -xe
 
-sed -i "s/\(config_opts\['chroot_setup_cmd']\) = '\(.*\)'/\1 = '\2 scl-utils-build'/" /etc/mock/default.cfg
-
-ed <<"EOF" /etc/mock/default.cfg
-$i
-
-[copr-be.cloud.fedoraproject.org_results_managerforlustre_manager-for-lustre_epel-7-x86_64_]
-name=added from: https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-x86_64/
-baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-x86_64/
-enabled=1
-
-[dotnet]
-name=CentOS-7 - DotNet
-baseurl=http://mirror.centos.org/centos/$releasever/dotnet/$basearch/
-enabled=1
-
-[mono-centos7-stable]
-name=mono-centos7-stable
-baseurl=http://download.mono-project.com/repo/centos7-stable/
-enabled=1
-
-.
-w
-q
-EOF
-
-chown -R mockbuild:mock /builddir
 
 cd /builddir/
-git clean -dfx
-rpkg make-source
-RELEASE=$(git rev-list HEAD | wc -l)
 
+rpmlint /builddir/device-scanner.spec
+yum install -y dnf
+make -f /builddir/.copr/Makefile srpm spec="/builddir/device-scanner.spec" outdir="/builddir/"
+
+chown -R mockbuild:mock /builddir
 su - mockbuild <<EOF
 set -xe
 cd /builddir/
-rpmlint \$PWD *.spec
-rpmbuild -bs --define epel\ 1 --define package_release\ $RELEASE --define _srcrpmdir\ \$PWD --define _sourcedir\ \$PWD *.spec
-mock iml-device-scanner-*.src.rpm -v --resultdir="/builddir" --rpmbuild-opts="--define package_release\ $RELEASE" --enable-network
+mock iml-device-scanner-*.src.rpm --resultdir="/builddir" --enable-network
 EOF

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/device-scanner",
-  "version": "2.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -39,9 +39,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.4.tgz",
-      "integrity": "sha512-GpQxofkdlHYxjHad98UUdNoMO7JrmzQZoAaghtNg14Gwg7YkohcrCoJEcEMSgllx4VIZ+mYw7ZHjfaeIagP/rg==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.2.tgz",
+      "integrity": "sha512-9NfEUDp3tgRhmoxzTpTo+lq+KIVFxZahuRX0LHF/9IzKHaWuoWsIrrJ61zw5cnnlGINX8lqJzXYfQTOICS5Q+A==",
       "dev": true
     },
     "abab": {
@@ -1803,9 +1803,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
       "dev": true
     },
     "combined-stream": {
@@ -5010,11 +5010,12 @@
       }
     },
     "jest-junit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-4.0.0.tgz",
-      "integrity": "sha512-Qb+h3a9DkZjlggv9JbY/AVLiiQ7CQB5/IJoMxWtOE/SXgQQMMbHdnlbAN1+w/2mAY8KgNtuLnrfMa5Lk5Wx6VQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-5.0.0.tgz",
+      "integrity": "sha512-GSruJTd90QX7rsUn2/mn733dQUY4WU21sbR103e2k/1lhHVwTY9bzlGbf53983g2chUhDppvvhntj0PyAqJawQ==",
       "dev": true,
       "requires": {
+        "jest-validate": "^23.0.1",
         "mkdirp": "^0.5.1",
         "strip-ansi": "^4.0.0",
         "xml": "^1.0.1"
@@ -6452,9 +6453,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.3.tgz",
-      "integrity": "sha512-CIWJNU+cFFdeA0GJSzzFkxiq2WuMvWZMlz6cV/EXhPlRnI3esSFMh+lNmyZ8z/X8O8C1U60Sc8puXALj4/WmZw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.4.tgz",
+      "integrity": "sha512-emsEZ2bAigL1lq6ssgkpPm1MIBqgeTvcp90NxOP5XDqprub/V/WS2Hfgih3mS7/1dqTUvhG+sxx1Dv8crnVexA==",
       "dev": true
     },
     "pretty-format": {
@@ -7004,9 +7005,9 @@
       }
     },
     "rollup": {
-      "version": "0.59.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.59.4.tgz",
-      "integrity": "sha512-ISiMqq/aJa+57QxX2MRcvLESHdJ7wSavmr6U1euMr+6UgFe6KM+3QANrYy8LQofwhTC1I7BcAdlLnDiaODs1BA==",
+      "version": "0.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.60.1.tgz",
+      "integrity": "sha512-LujiS7PH8DwKAphB2ldaSEF1EX9hWY9w+mct2b4DczC8tvn7qwmr9ZFLtM9IT7gPFYlmS8O1JdiLT/aEiBEcsA==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
@@ -7035,9 +7036,9 @@
       }
     },
     "rollup-plugin-filesize": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-filesize/-/rollup-plugin-filesize-1.5.0.tgz",
-      "integrity": "sha512-J5Ja0xgba4YqWthoui95TlLJLgcheh78vB0SXJTEyB2AfhspJEN6wFJHFzRStVYPtD0zIyg6A5H+2UhaX5bVcw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-filesize/-/rollup-plugin-filesize-2.0.0.tgz",
+      "integrity": "sha512-ZFwmrHvfAXLyYLK9mgiFDCDg3wncX/Dx5XLA9KDBqVu+Gi3zH7hvpjho36QZyyAmYm8iEwv1KGOCMdCernzo7A==",
       "dev": true,
       "requires": {
         "boxen": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,29 +2,27 @@
   "name": "@iml/device-scanner",
   "description": "Builds an in-memory representation of devices. Uses udev rules to handle change events.",
   "author": "IML Team",
-  "version": "2.1.1",
+  "version": "2.0.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "eslint": "eslint *.js **/*.js",
-    "test":
-      "jest --projects IML.DeviceScannerDaemon  --projects IML.ScannerProxyDaemon --projects IML.DeviceAggregatorDaemon --projects IML.StatefulPromise --projects IML.Types --projects IML.Listeners/MountEmitter --projects IML.CommonLibrary",
+    "test": "jest --projects IML.DeviceScannerDaemon  --projects IML.ScannerProxyDaemon --projects IML.DeviceAggregatorDaemon --projects IML.StatefulPromise --projects IML.Types --projects IML.Listeners/MountEmitter --projects IML.CommonLibrary",
     "coverage": "npm t -- --coverage",
     "test-watch": "npm t -- --watchAll",
     "pre-commit-test": "dotnet fable npm-test -- --no-cache",
-    "integration-test":
-      "jest -i --projects IML.IntegrationTestFramework/test --projects IML.IntegrationTest --testResultsProcessor='jest-junit'",
+    "integration-test": "jest -i --projects IML.IntegrationTestFramework/test --projects IML.IntegrationTest --testResultsProcessor='jest-junit'",
     "restore": "dotnet restore Root.fsproj && dotnet restore device-scanner.sln",
     "prebuild": "del-cli ./dist/**",
     "build": "rollup -c rollup-config.js",
-    "docs":
-      "mkdir -p ./dist/docs && remark ./IML.DeviceScannerDaemon/README.md -u remark-man > ./dist/docs/device-scanner.8",
-    "postbuild":
-      "cp-cli IML.Listeners/UdevListener/scripts/ dist/listeners && cp-cli IML.Listeners/UdevListener/udev-rules/ dist/listeners && cp-cli IML.Listeners/MountEmitter/systemd-units dist/listeners && cp-cli IML.DeviceScannerDaemon/systemd-units dist/device-scanner-daemon && cp-cli IML.DeviceAggregatorDaemon/systemd-units dist/device-aggregator-daemon && cp-cli IML.ScannerProxyDaemon/systemd-units dist/scanner-proxy-daemon && npm run docs",
+    "docs": "mkdir -p ./dist/docs && remark ./IML.DeviceScannerDaemon/README.md -u remark-man > ./dist/docs/device-scanner.8",
+    "postbuild": "cp-cli IML.Listeners/UdevListener/scripts/ dist/listeners && cp-cli IML.Listeners/UdevListener/udev-rules/ dist/listeners && cp-cli IML.Listeners/MountEmitter/systemd-units dist/listeners && cp-cli IML.DeviceScannerDaemon/systemd-units dist/device-scanner-daemon && cp-cli IML.DeviceAggregatorDaemon/systemd-units dist/device-aggregator-daemon && cp-cli IML.ScannerProxyDaemon/systemd-units dist/scanner-proxy-daemon && npm run docs",
     "premock": "docker run  -di --privileged --name mock intelhpdd/mock /usr/sbin/init",
     "mock": "docker cp -a ./ mock:/builddir",
     "postmock": "docker exec -i mock bash -xec './builddir/mock-build.sh'"
@@ -37,7 +35,10 @@
     "ancestorSeparator": " › ",
     "usePathForSuiteName": "true"
   },
-  "pre-commit": ["eslint", "pre-commit-test"],
+  "pre-commit": [
+    "eslint",
+    "pre-commit-test"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:intel-hpdd/device-scanner.git"
@@ -56,14 +57,14 @@
     "fable-utils": "^1.0.6",
     "jest": "^23.1.0",
     "jest-fable-preprocessor": "^1.4.0",
-    "jest-junit": "^4.0.0",
+    "jest-junit": "^5.0.0",
     "pre-commit": "1.2.2",
-    "prettier": "^1.13.3",
+    "prettier": "^1.13.4",
     "remark-cli": "^5.0.0",
     "remark-man": "^5.1.0",
-    "rollup": "^0.59.4",
+    "rollup": "^0.60.1",
     "rollup-plugin-cleanup": "^3.0.0-beta.1",
     "rollup-plugin-fable": "^1.1.1",
-    "rollup-plugin-filesize": "^1.5.0"
+    "rollup-plugin-filesize": "^2.0.0"
   }
 }


### PR DESCRIPTION
device-scanner currently uses rpkg to build everything (including source).

This makes the spec heavier and slower than it needs to be in terms of building, as everything is pulled in and done inside a mock container.

Ideally, we should be able to use the `make srpm` option as that would allow us to rebuild entirely from the Copr interface. Unfortunately the chroot is pinned to a newer fedora and does not include a way to alter it's provided mock config, so it's not an option (track: https://pagure.io/copr/copr/issue/310).

That leaves us with the option to use module-tools to build locally and push changes via `copr-cli`, which is what this patch will implement.