### PR TITLE
Use module-tools to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ jest_0
 .paket/Paket.Restore.targets
 id_rsa
 id_rsa.pub
+_topdir
+copr-local.mk

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ end
 
 Vagrant.configure('2') do |config|
   config.vm.box = 'manager-for-lustre/centos75-1804-device-scanner'
-  config.vm.box_version = '0.0.3'
+  config.vm.box_version = '0.0.4'
 
   INT_NET_NAME = "scanner-net#{NAME_SUFFIX}".freeze
 
@@ -92,6 +92,9 @@ __EOF
     device_scanner.vm.provision 'build', type: 'shell', inline: <<-SHELL
       rm -rf /builddir
       cp -r /vagrant /builddir
+      SHELL
+
+    device_scanner.vm.provision 'install', type: 'shell', inline: <<-SHELL
       cd /builddir
       ./mock-build.sh
       find . -name "iml-device-scanner-[0-9]*.x86_64.rpm" -printf "%f" | xargs yum install -y
@@ -172,18 +175,18 @@ __EOF
       cd /builddir
       npm i --ignore-scripts
       cert-sync /etc/pki/tls/certs/ca-bundle.crt
-      scl enable rh-dotnet20 "npm run restore"
+      npm run restore
     SHELL
 
     test.vm.provision 'integration-test', type: 'shell', inline: <<-SHELL
       cd /builddir
-      scl enable rh-dotnet20 "dotnet fable npm-run integration-test"
+      dotnet fable npm-run integration-test
       cp /builddir/results.xml /vagrant
     SHELL
 
     test.vm.provision 'update-snapshot', type: 'shell', run: 'never', inline: <<-SHELL
       cd /builddir
-      scl enable rh-dotnet20 "dotnet fable npm-run integration-test -- -u"
+      dotnet fable npm-run integration-test -- -u
       cp -rf IML.IntegrationTest/__snapshots__ /vagrant/IML.IntegrationTest/__snapshots__
     SHELL
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ end
 
 Vagrant.configure('2') do |config|
   config.vm.box = 'manager-for-lustre/centos75-1804-device-scanner'
-  config.vm.box_version = '0.0.4'
+  config.vm.box_version = '0.0.5'
 
   INT_NET_NAME = "scanner-net#{NAME_SUFFIX}".freeze
 
@@ -92,7 +92,7 @@ __EOF
     device_scanner.vm.provision 'build', type: 'shell', inline: <<-SHELL
       rm -rf /builddir
       cp -r /vagrant /builddir
-      SHELL
+    SHELL
 
     device_scanner.vm.provision 'install', type: 'shell', inline: <<-SHELL
       cd /builddir

--- a/device-scanner.spec
+++ b/device-scanner.spec
@@ -1,3 +1,5 @@
+%{?!package_release: %global package_release 1}
+
 %define     base_name device-scanner
 %define     proxy_name scanner-proxy
 %define     mount_name mount-emitter
@@ -7,8 +9,8 @@
 %define     mount_prefixed iml-%{mount_name}
 %define     aggregator_prefixed iml-%{aggregator_name}
 Name:       %{base_prefixed}
-Version:    2.0.0
-Release:    1%{?dist}
+Version:    2.2.0
+Release:    %{package_release}%{?dist}
 Summary:    Maintains data of block and ZFS devices
 License:    MIT
 Group:      System Environment/Libraries
@@ -18,12 +20,6 @@ URL:        https://github.com/intel-hpdd/%{base_name}
 Source0:    %{base_prefixed}-%{version}.tgz
 
 ExclusiveArch: %{nodejs_arches}
-
-BuildRequires: nodejs-packaging
-BuildRequires: nodejs
-BuildRequires: npm
-BuildRequires: mono-devel
-BuildRequires: %{?scl_prefix}rh-dotnet20
 
 %{?systemd_requires}
 BuildRequires: systemd
@@ -55,17 +51,10 @@ device-aggregator-daemon aggregates data received from device
 scanner instances over HTTPS.
 
 %prep
-%setup
+%setup -q -n package
 
 %build
-cert-sync /etc/pki/tls/certs/ca-bundle.crt
-scl enable rh-dotnet20 - << EOF
-set -e
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-npm i --ignore-scripts
-npm run restore
-dotnet fable npm-build
-EOF
+#nothing to do
 
 %install
 mkdir -p %{buildroot}%{_unitdir}
@@ -234,16 +223,16 @@ fi
 %systemd_postun_with_restart %{aggregator_name}.socket
 
 %changelog
-* Mon May 14 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.1.1-1
+* Mon May 14 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.0.0-1
 - Add mount detection to device-scanner
 - Integrate device-aggregator
 - Move device munging inside aggregator
 
-* Mon Feb 26 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.1.0-2
+* Mon Feb 26 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.0.0-1
 - Make scanner-proxy a sub-package (separate rpm)
 - Handle upgrade scenarios
 
-* Thu Feb 15 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.1.0-1
+* Thu Feb 15 2018 Tom Nabarro <tom.nabarro@intel.com> - 2.0.0-1
 - Minor change, integrate scanner-proxy project
 
 * Mon Jan 22 2018 Joe Grund <joe.grund@intel.com> - 2.0.0-1

--- a/mock-build.sh
+++ b/mock-build.sh
@@ -9,6 +9,7 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 npm i --ignore-scripts
 npm run restore
 dotnet fable npm-build
+npm pack
 rpmlint /builddir/*.spec
 make DRYRUN=false srpm
 

--- a/mock-build.sh
+++ b/mock-build.sh
@@ -1,41 +1,20 @@
-#!/bin/bash -xe
+#!/bin/bash
 
-sed -i "s/\(config_opts\['chroot_setup_cmd']\) = '\(.*\)'/\1 = '\2 scl-utils-build'/" /etc/mock/default.cfg
-
-ed <<"EOF" /etc/mock/default.cfg
-$i
-
-[copr-be.cloud.fedoraproject.org_results_managerforlustre_manager-for-lustre_epel-7-x86_64_]
-name=added from: https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-x86_64/
-baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-x86_64/
-enabled=1
-
-[dotnet]
-name=CentOS-7 - DotNet
-baseurl=http://mirror.centos.org/centos/$releasever/dotnet/$basearch/
-enabled=1
-
-[mono-centos7-stable]
-name=mono-centos7-stable
-baseurl=http://download.mono-project.com/repo/centos7-stable/
-enabled=1
-
-.
-w
-q
-EOF
-
-chown -R mockbuild:mock /builddir
 
 cd /builddir/
-git clean -dfx
-rpkg make-source
-RELEASE=$(git rev-list HEAD | wc -l)
 
+rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+yum install -y make dotnet-sdk-2.1 mono-devel nodejs npm
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+npm i --ignore-scripts
+npm run restore
+dotnet fable npm-build
+rpmlint /builddir/*.spec
+make DRYRUN=false srpm
+
+chown -R mockbuild:mock /builddir
 su - mockbuild <<EOF
 set -xe
 cd /builddir/
-rpmlint \$PWD *.spec
-rpmbuild -bs --define epel\ 1 --define package_release\ $RELEASE --define _srcrpmdir\ \$PWD --define _sourcedir\ \$PWD *.spec
-mock iml-device-scanner-*.src.rpm -v --resultdir="/builddir" --rpmbuild-opts="--define package_release\ $RELEASE" --enable-network
+mock _topdir/SRPMS/*.src.rpm --resultdir="/builddir" --enable-network
 EOF

--- a/mock-build.sh
+++ b/mock-build.sh
@@ -4,12 +4,14 @@
 cd /builddir/
 
 rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
-yum install -y make dotnet-sdk-2.1 mono-devel nodejs npm
+yum install -y make dotnet-sdk-2.1 mono-devel nodejs npm spectool
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 npm i --ignore-scripts
 npm run restore
 dotnet fable npm-build
 npm pack
+mkdir -p _topdir/SOURCES/
+cp -rf iml-device-scanner-*.tgz ./_topdir/SOURCES
 rpmlint /builddir/*.spec
 make DRYRUN=false srpm
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/device-scanner",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -35,7 +35,7 @@
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "integrity": "sha1-4Xfmme4bjCLSMXTKqnQiZEOJUJ8=",
       "dev": true
     },
     "@types/node": {
@@ -2656,7 +2656,7 @@
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+      "integrity": "sha1-CQuz7gG2+AGoqL6Z0xcQs0Irsxc=",
       "dev": true
     },
     "fill-range": {
@@ -5012,7 +5012,7 @@
     "jest-junit": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-4.0.0.tgz",
-      "integrity": "sha512-Qb+h3a9DkZjlggv9JbY/AVLiiQ7CQB5/IJoMxWtOE/SXgQQMMbHdnlbAN1+w/2mAY8KgNtuLnrfMa5Lk5Wx6VQ==",
+      "integrity": "sha1-avBNQ5QNfoHcfTfsG4DJdVHZHoA=",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1",
@@ -7006,7 +7006,7 @@
     "rollup": {
       "version": "0.59.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.59.4.tgz",
-      "integrity": "sha512-ISiMqq/aJa+57QxX2MRcvLESHdJ7wSavmr6U1euMr+6UgFe6KM+3QANrYy8LQofwhTC1I7BcAdlLnDiaODs1BA==",
+      "integrity": "sha1-b4D3AXwiZn/xvz5irfhiSkTMRKo=",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
@@ -7037,7 +7037,7 @@
     "rollup-plugin-filesize": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-filesize/-/rollup-plugin-filesize-1.5.0.tgz",
-      "integrity": "sha512-J5Ja0xgba4YqWthoui95TlLJLgcheh78vB0SXJTEyB2AfhspJEN6wFJHFzRStVYPtD0zIyg6A5H+2UhaX5bVcw==",
+      "integrity": "sha1-u1hBJC2IvlfyMcnoo6VBklOSF4s=",
       "dev": true,
       "requires": {
         "boxen": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,29 +2,27 @@
   "name": "@iml/device-scanner",
   "description": "Builds an in-memory representation of devices. Uses udev rules to handle change events.",
   "author": "IML Team",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "eslint": "eslint *.js **/*.js",
-    "test":
-      "jest --projects IML.DeviceScannerDaemon  --projects IML.ScannerProxyDaemon --projects IML.DeviceAggregatorDaemon --projects IML.StatefulPromise --projects IML.Types --projects IML.Listeners/MountEmitter --projects IML.CommonLibrary",
+    "test": "jest --projects IML.DeviceScannerDaemon  --projects IML.ScannerProxyDaemon --projects IML.DeviceAggregatorDaemon --projects IML.StatefulPromise --projects IML.Types --projects IML.Listeners/MountEmitter --projects IML.CommonLibrary",
     "coverage": "npm t -- --coverage",
     "test-watch": "npm t -- --watchAll",
     "pre-commit-test": "dotnet fable npm-test -- --no-cache",
-    "integration-test":
-      "jest -i --projects IML.IntegrationTestFramework/test --projects IML.IntegrationTest --testResultsProcessor='jest-junit'",
+    "integration-test": "jest -i --projects IML.IntegrationTestFramework/test --projects IML.IntegrationTest --testResultsProcessor='jest-junit'",
     "restore": "dotnet restore Root.fsproj && dotnet restore device-scanner.sln",
     "prebuild": "del-cli ./dist/**",
     "build": "rollup -c rollup-config.js",
-    "docs":
-      "mkdir -p ./dist/docs && remark ./IML.DeviceScannerDaemon/README.md -u remark-man > ./dist/docs/device-scanner.8",
-    "postbuild":
-      "cp-cli IML.Listeners/UdevListener/scripts/ dist/listeners && cp-cli IML.Listeners/UdevListener/udev-rules/ dist/listeners && cp-cli IML.Listeners/MountEmitter/systemd-units dist/listeners && cp-cli IML.DeviceScannerDaemon/systemd-units dist/device-scanner-daemon && cp-cli IML.DeviceAggregatorDaemon/systemd-units dist/device-aggregator-daemon && cp-cli IML.ScannerProxyDaemon/systemd-units dist/scanner-proxy-daemon && npm run docs",
+    "docs": "mkdir -p ./dist/docs && remark ./IML.DeviceScannerDaemon/README.md -u remark-man > ./dist/docs/device-scanner.8",
+    "postbuild": "cp-cli IML.Listeners/UdevListener/scripts/ dist/listeners && cp-cli IML.Listeners/UdevListener/udev-rules/ dist/listeners && cp-cli IML.Listeners/MountEmitter/systemd-units dist/listeners && cp-cli IML.DeviceScannerDaemon/systemd-units dist/device-scanner-daemon && cp-cli IML.DeviceAggregatorDaemon/systemd-units dist/device-aggregator-daemon && cp-cli IML.ScannerProxyDaemon/systemd-units dist/scanner-proxy-daemon && npm run docs",
     "premock": "docker run  -di --privileged --name mock intelhpdd/mock /usr/sbin/init",
     "mock": "docker cp -a ./ mock:/builddir",
     "postmock": "docker exec -i mock bash -xec './builddir/mock-build.sh'"
@@ -37,7 +35,10 @@
     "ancestorSeparator": " › ",
     "usePathForSuiteName": "true"
   },
-  "pre-commit": ["eslint", "pre-commit-test"],
+  "pre-commit": [
+    "eslint",
+    "pre-commit-test"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:intel-hpdd/device-scanner.git"


### PR DESCRIPTION
device-scanner currently uses rpkg to build everything (including source).

This makes the spec heavier and slower than it needs to be in terms of building, as everything is pulled in and done inside a mock container.

Ideally, we should be able to use the make srpm option as that would allow us to rebuild entirely from the Copr interface. Unfortunately the chroot is pinned to a newer fedora and does not include a way to alter it's provided mock config, so it's not an option (track: https://pagure.io/copr/copr/issue/310).

That leaves us with the option to use module-tools to build locally and push changes via copr-cli, which is what this patch will implement.

Signed-off-by: Joe Grund <joe.grund@intel.com>